### PR TITLE
Feat fast build vs benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,38 @@
+# Pollard benchmarks — OPTIONAL
+
+**You do not need anything in this folder to make a Pollard model.** The build (quantize)
+produces the model; everything here only *measures* how good it already is. These are the
+gold-card reproduction and R&D tools — they were how *we* proved Pollard works and tuned the
+allocation. Run them only if you want to verify or reproduce our published numbers.
+
+## Just want the model? (the fast path — minutes)
+
+```bash
+pollard --gguf model-f16.gguf --run          # detect dense/MoE, build ONE model, no eval
+```
+Dense → imatrix-guided K-quant ladder. MoE → the automap PollardMix. No comparison bars, no
+perplexity, no sensitivity sweep. That's the whole job.
+
+## Want to reproduce the gold-card numbers? (opt-in — hours)
+
+```bash
+pollard --gguf model-f16.gguf --benchmark --run     # ALSO build the 3-bar comparison + PPL
+```
+This adds the **benchmark**: the 3-bar board (uniform-low / PollardMix / uniform-high) and the
+full metric suite, so you can confirm PollardMix beats uniform at matched size.
+
+### The pieces (run individually if you want)
+
+| tool | measures | notes |
+|---|---|---|
+| `pollard-eval`  | trajectory-divergence quality | quick sanity |
+| `pollard-kl`    | KL-to-f16 + top-1 (torch) | small models |
+| `llama-perplexity --kl-divergence` | Mean/Median KLD + top-1 | big models, vs an f16/Q8/Q6 base |
+| `pollard-scorecard` | the standardized gold-card scorecard | from a results.json |
+| `pollard-sensitivity` | measured per-group KL profile (the MoE knapsack input) | **hours** (2·layers passes), MoE-only |
+
+## Why this is separated
+
+Shipping the benchmark *inside* the default build made a simple "shrink my model" run take
+hours (three builds + evals instead of one). The model was never the slow part — the
+measurement was. So: **build = default and fast; benchmark = here and opt-in.**

--- a/skills/pollard/SKILL.md
+++ b/skills/pollard/SKILL.md
@@ -25,6 +25,16 @@ pollard --gguf model-f16.gguf --imatrix model.imatrix --run           # detect +
 the user never picks a tool. The manual steps below are exactly what it runs; read on to
 drive a path yourself or understand what `pollard` chose.
 
+> ### Build ≠ benchmark — the default is FAST
+> Making a Pollard model is just the **build** (quantize): **one model, minutes, no eval.**
+> The PPL / KLD / top-1 / 3-bar comparison / sensitivity sweep are the **benchmark** — they
+> only *measure* the model and take **hours**. They are **opt-in**, not part of a normal build.
+> - **Just make the model:** `pollard --gguf model.gguf --run` (one model, no eval).
+> - **Reproduce our gold-card numbers:** add `--benchmark` (3-bar board + full metrics — hours).
+>
+> Never run the benchmark or the sensitivity sweep as part of a plain build — that's the
+> mistake that turned a minutes-long shrink into a 3-hour run. See `benchmarks/README.md`.
+
 ## STEP 0 — detect the model type FIRST (this decides everything)
 
 ```bash
@@ -64,29 +74,27 @@ Optional flagship extreme rung: an **automap 1-bit trellis mix** (the "gold-card
 
 ---
 
-## MoE path — automap measured expert-allocation
+## MoE path
 
-This is where measured allocation genuinely beats uniform (crush cold experts, protect
-the hot set). `pollard-automap` emits the 3-bar build (uniform-low / PollardMix / uniform-high).
+### MoE QUALITY win — the MEASURED allocator (this is the proven one; do NOT reinvent it)
 
-### MoE decoupled (imatrix-FREE) — the robust default for a big MoE
-
-A trellis mix (IQ1_KT/IQ2_KT experts) **hard-requires an imatrix**, and a MoE imatrix is
-the swamp: rare experts don't route, coverage is partial, the compute is 6+ hours and dies
-if interrupted. **Don't force it.** For a big MoE, build the automap mix from **K-quant
-atoms**, which read NO imatrix at all — no coverage problem, no long imatrix step, kill-proof:
-
+The quality win on a MoE (and on dense) is **`pollard-sensitivity` → `pollard-fit --sensitivity`**:
+it CRUSHES one tensor group at a time and measures the *true KL cost*, then a knapsack spends
+bits where the measurement — not a guess — says they matter. **Measured, shipped, and proven
+to beat uniform imatrix-IQ at matched size on both a MoE (granite-3B-a800m, 40 experts) AND a
+dense (Qwen2.5-1.5B)** — see `assets/kl_win.png`. Do not build a second allocator; use this one.
 ```bash
-# 1. FULL tensor list (dry-run at a non-low type so it can't abort mid-list):
-llama-quantize --dry-run moe-f16.gguf x.gguf Q6_K > tensors.txt
-# 2. automap --no-imatrix: K-quant mix straight off the F16 (body q2_k / protect q3_k).
-#    NO imatrix flag, NO calib, NO coverage pins — every atom is a K-quant.
-pollard-automap --tensors tensors.txt --model moe-f16.gguf --no-imatrix --out build.bat
-# 3. run build.bat -> uniform-Q2_K / PollardMix / uniform-Q3_K_M + PPL each
+pollard-sensitivity --gguf moe-f16.gguf --imatrix moe.imatrix --eval held.txt --out moe.sens.json
+pollard-fit --gguf moe-f16.gguf --ram 16 --imatrix moe.imatrix --sensitivity moe.sens.json --out moe-pollard.gguf
 ```
-Rule of thumb: **`imatrix = dense`, `automap = MoE`, and MoE → `--no-imatrix` unless you
-already have a well-covered diverse imatrix.** The trellis path below is the extreme-low
-variant, only worth it when a covered imatrix is cheap to make.
+Cost: the sweep is ~2·num_layers passes (one-time per model). Note: `imatrix magnitude LIES`
+(big activations ≠ high KL) — that's exactly why the measured sweep exists; don't allocate on
+raw imatrix importance.
+
+### MoE trellis (imatrix) — the extreme-low 1-bit-class variant (only with a covered imatrix)
+
+`pollard-automap` emits the 3-bar 1-bit-class build (uniform-IQ1 / PollardMix / uniform-IQ2).
+This is the extreme-low showcase (the 7B/14B gold-cards), NOT the general allocator above.
 
 ### MoE trellis (imatrix) — the extreme-low variant (only with a covered imatrix)
 
@@ -109,6 +117,15 @@ more diverse calib (more experts routed), **or just use `--no-imatrix`** (above)
 beats uniform-low on PPL/KL/top-1. If it drifts toward uniform-high size, reject and
 tighten the crush.
 
+### MoE with NO imatrix — `--no-imatrix` (robustness fallback, NOT a quality win)
+
+If a covered imatrix is impractical (the swamp above), `pollard-automap --no-imatrix` builds a
+K-quant mix straight off the F16 — no imatrix, no coverage problem, kill-proof. **Be honest
+about what it is: a robustness fallback.** Measured on Qwen3-30B-A3B it did NOT beat the stock
+`Q2_K` preset (that preset is itself a tuned mix). So for a real MoE quality win use the
+MEASURED allocator above; reach for `--no-imatrix` only to *get a build at all* when you can't
+make an imatrix, and compare it against stock `Q2_K` before shipping.
+
 **MoE measured K-quant ladder (alternative to the trellis mix)** — the KL knapsack that
 beats uniform, for shipping IQ3/IQ4/Q6 sizes:
 ```bash
@@ -118,6 +135,23 @@ pollard-experts --gguf moe-f16.gguf --imatrix moe.imatrix          # measured ho
 ```
 
 ---
+
+### Giant MoE that won't fit even quantized (e.g. Kimi K2, ~1T params) — PRUNE first
+
+Quant has a floor: params x 1 bit. A 1T MoE is ~125 GB at 1-bit and unusable that low — you
+**cannot quantize a trillion-param MoE onto one small box.** The lever is **expert pruning**:
+a big MoE has many cold/redundant experts (Kimi K2: 384 experts, 8 active). Drop the cold
+third-to-half FIRST (structurally smaller model), THEN quantize:
+```bash
+pollard-pack  --gguf kimi-f16.gguf --emit-plan plan.json      # rank experts (forecast + which to drop)
+pollard-prune --gguf kimi-f16.gguf --keep 0.5 --out kimi-pruned.gguf   # execute: rewrite a smaller GGUF
+pollard-automap --tensors <dry-run kimi-pruned> --model kimi-pruned.gguf --no-imatrix --out build.bat
+```
+`--score imatrix` (with a diverse-calib imatrix) keeps the experts the calib actually routed
+to (REAP-correct); `magnitude` is the zero-calib default. Keep >= the model's active-expert
+count. **Producing the artifact needs the source weights + storage + a big box** — the tool
+runs on the box that holds the model; a user without the disk downloads the finished small
+build instead of making it.
 
 ## Runtime targets (where the build will actually run)
 
@@ -190,6 +224,7 @@ pollard-palette --gguf model-f16.gguf --imatrix model.imatrix                 # 
 | `pollard-sensitivity` | measured per-group KL profile (the knapsack input) | **MoE only** |
 | `pollard-probe` | CHEAP in-process sensitivity (no GGUF/imatrix, any box) | any (research) |
 | `pollard-pack` | Cerebras wafer capacity + expert-prune plan (forecast) | MoE (lever) |
+| `pollard-prune` | REAP-style expert pruning — drop cold experts, rewrite a SMALLER GGUF | **MoE only** |
 | `pollard-export` | vLLM/SGLang GPTQ (4/8 dynamic) checkpoint | any |
 | `pollard-abliterate` | optional refusal-direction ablation (pre-quant) | any |
 | `pollard-experts` | measured hot-expert report | **MoE only** |

--- a/tools/pollard_auto.py
+++ b/tools/pollard_auto.py
@@ -58,6 +58,10 @@ def main():
     ap.add_argument("--eval", default="wikitext2_test.txt")
     ap.add_argument("--bin", help="llama.cpp bin dir (for the MoE dry-run/build)")
     ap.add_argument("--run", action="store_true", help="execute the path (default: plan/print it)")
+    ap.add_argument("--benchmark", "--reproduce", dest="benchmark", action="store_true",
+                    help="ALSO run the gold-card benchmark (3-bar comparison + PPL) — the "
+                         "hour-long validation. OFF by default: a normal build makes ONE model "
+                         "fast and skips the eval. Use this only to reproduce our published numbers.")
     ap.add_argument("--force-dense", action="store_true", help="override detection -> dense path")
     ap.add_argument("--force-moe", action="store_true", help="override detection -> MoE path")
     a = ap.parse_args()
@@ -105,14 +109,21 @@ def main():
         with open(tensors, "w") as f:
             subprocess.run([binq, "--dry-run", a.gguf, "x.gguf", "Q6_K"],
                            stdout=f, stderr=subprocess.STDOUT)
-    print("   2) automap emits the MoE build recipe:")
+    mode = "gold-card BENCHMARK (3 bars + PPL)" if a.benchmark else "fast build (PollardMix only, no eval)"
+    print(f"   2) automap emits the MoE build recipe -> {mode}:")
     am = ["pollard-automap", "--tensors", tensors, "--model", a.gguf,
           "--out", os.path.join(here, "pollard_auto_build.bat")]
     am += ["--no-imatrix"] if kfree else ["--imatrix", a.imatrix]
+    if not a.benchmark:
+        am += ["--mix-only", "--no-eval"]   # a plain build = ONE model, no benchmark
     if a.bin: am += ["--bin", a.bin]
     _run(am, a.run, cwd=here)
-    bars = "uniform-Q2_K / PollardMix / uniform-Q3_K_M" if kfree else "uniform-IQ1 / PollardMix / uniform-IQ2"
-    print(f"   3) run the emitted build script -> {bars} + PPL.")
+    if a.benchmark:
+        bars = "uniform-Q2_K / PollardMix / uniform-Q3_K_M" if kfree else "uniform-IQ1 / PollardMix / uniform-IQ2"
+        print(f"   3) run the emitted build script -> {bars} + PPL (the benchmark).")
+    else:
+        print("   3) run the emitted build script -> ONE PollardMix model, no eval (fast).")
+        print("      (want the published gold-card numbers? re-run with --benchmark.)")
     print("      (pollard_auto_build.bat — run it on the box with a llama.cpp build.)")
     if not a.run:
         print("\n   plan only — re-run with --run to execute. (dense would run pollard-fit directly.)")

--- a/tools/pollard_automap.py
+++ b/tools/pollard_automap.py
@@ -111,6 +111,15 @@ def _bar_type(atom):
     its preset; trellis/I-quant -> the uppercase type name)."""
     a = _atom(atom)
     return _BAR_PRESET.get(a, a.upper())
+
+
+def _cq(atom):
+    """The EXACT ggml type name --custom-q expects. K-quants are `qN_K` (capital K, e.g.
+    q3_K); i-/trellis quants are all-lowercase (iq1_kt). llama-quantize rejects `q3_k`
+    ('Invalid quantization type') — the tensor-type table is case-sensitive on the K."""
+    a = _atom(atom)
+    m = re.match(r"(q\d)_k$", a)
+    return f"{m.group(1)}_K" if m else a
 # Frontier mixed-ultra-low formats (e.g. Hy4 MIX-STQ1_0's sparse-ternary STQ1_0) map onto
 # the nearest thing this runtime can actually emit: Bitnet ternary.
 ALIASES = {"stq1_0": "iq1_bn", "stq2_0": "iq2_bn"}
@@ -134,9 +143,10 @@ def recipe_flags(n_layers, is_moe, body="iq1_kt", protect="iq2_kt"):
     If body+protect are BOTH K-quants, the recipe is imatrix-free (the decoupled MoE
     path): the one hard-coded trellis atom (the shared-expert writer) drops to the
     protect K-quant so no tensor needs an importance matrix."""
-    body, protect = _atom(body), _atom(protect)
     kfree = is_kquant(body) and is_kquant(protect)      # fully imatrix-free build?
     shexp_down = protect if kfree else "iq3_kt"         # trellis atom only when imatrix is present
+    # custom-q needs the exact ggml type name (K-quants capital-K: q3_K, not q3_k).
+    body, protect, shexp_down = _cq(body), _cq(protect), _cq(shexp_down)
     flags = ["--output-tensor-type Q6_K", "--token-embedding-type Q4_K"]  # head/embed: never < 4-bit
     cq = []
     # --custom-q is FIRST-MATCH-WINS (verified via dry-run): list overrides first.
@@ -180,8 +190,10 @@ def emit_bat(a, n_layers, is_moe, names):
         return (f"%BIN%\\llama-quantize.exe {im_flag}{extra} %SRC% "
                 f"{stem}-{name}.gguf {typ} 1>> %LOG% 2>&1")
     def ppl(name):
+        # PPL is offload-invariant (ngl changes speed, not the number) — so a partial
+        # offload keeps every bar comparable AND stops a big bar OOMing the card.
         return (f"%BIN%\\llama-perplexity.exe -m {stem}-{name}.gguf -f %EV% -c 2048 "
-                f"-ngl 99 1>> %LOG% 2>&1")
+                f"-ngl {a.ngl} 1>> %LOG% 2>&1")
     pin_extra = f' --custom-q "{pin_cq[:-1]}"' if pins else ""   # uniform bars need the pins too
     if pins:
         L += [f"echo == pinned {len(pins)} imatrix-uncovered tensor(s) to q6_K "
@@ -211,6 +223,9 @@ def main():
     ap.add_argument("--model", required=True, help="source F16 gguf path (as seen on the box)")
     ap.add_argument("--imatrix", default="ik.imatrix")
     ap.add_argument("--eval", default="wikitext2_test.txt")
+    ap.add_argument("--ngl", type=int, default=99,
+                    help="GPU layers for the PPL eval. Lower it for a big build that would OOM "
+                         "the card (PPL is offload-invariant, so bars stay comparable).")
     ap.add_argument("--bin", default=r"C:\pollard\ik_llama.cpp\build\bin")
     ap.add_argument("--log", default=r"C:\pollard\bench\automap.log")
     ap.add_argument("--out", default="build_automap.bat")

--- a/tools/pollard_automap.py
+++ b/tools/pollard_automap.py
@@ -198,21 +198,27 @@ def emit_bat(a, n_layers, is_moe, names):
     if pins:
         L += [f"echo == pinned {len(pins)} imatrix-uncovered tensor(s) to q6_K "
               f"(covered={ncov}) == 1>> %LOG% 2>&1"]
-    # baseline (uniform at the crush tier) — the bar the Mix must beat at ~same size
-    L += [f"echo ==uniform {body}== 1>> %LOG% 2>&1",
-          build(f"u-{body}", _bar_type(body), pin_extra), ppl(f"u-{body}"), ""]
-    # ceiling (uniform at the protect tier)
-    L += [f"echo ==uniform {protect}== 1>> %LOG% 2>&1",
-          build(f"u-{protect}", _bar_type(protect), pin_extra), ppl(f"u-{protect}"), ""]
-    # optional rival: a strong mixed/uniform low-bit to beat head-to-head (Grok's 4th bar)
-    if a.rival:
-        rv = _atom(a.rival)
-        L += [f"echo ==rival uniform {rv}== 1>> %LOG% 2>&1",
-              build(f"rival-{rv}", _bar_type(rv)), ppl(f"rival-{rv}"), ""]
-    # PollardMix: base fills with the body atom, custom-q protects the sensitive roles
+    # --no-eval skips PPL (a plain user BUILD doesn't need the benchmark); the 3-bar
+    # comparison (uniform baseline + ceiling) is the BENCHMARK, emitted only when NOT --mix-only.
+    def maybe_ppl(name):
+        return [] if a.no_eval else [ppl(name)]
+    if not a.mix_only:
+        # baseline (uniform at the crush tier) — the bar the Mix must beat at ~same size
+        L += [f"echo ==uniform {body}== 1>> %LOG% 2>&1",
+              build(f"u-{body}", _bar_type(body), pin_extra), *maybe_ppl(f"u-{body}"), ""]
+        # ceiling (uniform at the protect tier)
+        L += [f"echo ==uniform {protect}== 1>> %LOG% 2>&1",
+              build(f"u-{protect}", _bar_type(protect), pin_extra), *maybe_ppl(f"u-{protect}"), ""]
+        # optional rival: a strong mixed/uniform low-bit to beat head-to-head (Grok's 4th bar)
+        if a.rival:
+            rv = _atom(a.rival)
+            L += [f"echo ==rival uniform {rv}== 1>> %LOG% 2>&1",
+                  build(f"rival-{rv}", _bar_type(rv)), *maybe_ppl(f"rival-{rv}"), ""]
+    # PollardMix: base fills with the body atom, custom-q protects the sensitive roles. This is
+    # the deliverable — always emitted; with --mix-only it's the ONLY thing built (the fast path).
     mix_extra = " ".join(flags) + f' --custom-q "{cqs}"'
     L += ["echo ==PollardMix (automap)== 1>> %LOG% 2>&1",
-          build("mix", _bar_type(body), mix_extra), ppl("mix"), ""]
+          build("mix", _bar_type(body), mix_extra), *maybe_ppl("mix"), ""]
     L += [f"echo AUTOMAP_DONE_EXIT_%ERRORLEVEL% 1>> %LOG% 2>&1"]
     return "\n".join(L)
 
@@ -235,6 +241,13 @@ def main():
                     help="imatrix-FREE MoE mix: K-quant atoms (body q2_k / protect q4_k) that "
                          "build straight off the F16 — no 6-hour, coverage-hungry imatrix step. "
                          "The robust default for a big MoE where a covered imatrix is impractical.")
+    ap.add_argument("--mix-only", dest="mix_only", action="store_true",
+                    help="emit ONLY the PollardMix build — the deliverable model. Skips the "
+                         "uniform baseline/ceiling bars (those are the BENCHMARK). This is the "
+                         "fast user-build path; without it you get the full 3-bar comparison.")
+    ap.add_argument("--no-eval", dest="no_eval", action="store_true",
+                    help="skip the PPL eval lines — a plain build doesn't need the benchmark. "
+                         "(Reproduce the gold-card numbers with the benchmark path instead.)")
     ap.add_argument("--rival", default="", help="optional 4th bar: a uniform tier to beat head-to-head, e.g. iq2_xxs")
     ap.add_argument("--allow-dense", action="store_true",
                     help="permit a DENSE model (automap is the MoE path; dense uses imatrix "


### PR DESCRIPTION
pollard <model> --run now builds ONE model, fast, no eval (MoE → automap --mix-only --no-eval; dense → pollard-fit, already eval-free). That's the whole "shrink my model" job — minutes.
--benchmark / --reproduce is the opt-in flag that runs the gold-card 3-bar + PPL harness (the hours-long validation). Off by default.
pollard-automap got --mix-only (emit just the deliverable mix) and --no-eval (skip PPL).
benchmarks/README.md — new folder: "you don't need this to make a model; it's optional reproduction."
SKILL.md leads with "build ≠ benchmark" so agents never run the 3-hour path for a plain build.