### PR TITLE
MoE recipe: protect attn_v/k (Session-2 fix) — 30B MoE board goes GREEN

### DIFF
--- a/tools/pollard_automap.py
+++ b/tools/pollard_automap.py
@@ -162,8 +162,12 @@ def recipe_flags(n_layers, is_moe, body="iq1_kt", protect="iq2_kt"):
         cq += [f"ffn_gate_exps={body}", f"ffn_up_exps={body}", f"ffn_down_exps={protect}",
                "ffn_gate_inp=q6_K",                       # router: never crushed
                f"ffn_gate_shexp={protect}", f"ffn_up_shexp={protect}", f"ffn_down_shexp={shexp_down}"]
-    # (3) general roles: attn k,v to the body atom; q + output protected; ffn_down LOW.
-    cq += [f"attn_k={body}", f"attn_v={body}",
+    # (3) general roles. Grok's policy: PROTECT attn v/o (they carry the distribution); q/k
+    # are less critical. On DENSE the shipped 7B/14B recipe crushed k,v and still won, so keep
+    # it. On MoE, crushing attn_v was measured to LOSE KLD vs uniform IQ1 (30B: mix 0.371 >
+    # uniform 0.360) — protect attn_v/k there (attention is a small fraction of a MoE anyway).
+    attn_kv = protect if (kfree or is_moe) else body
+    cq += [f"attn_k={attn_kv}", f"attn_v={attn_kv}",
            f"attn_q={protect}", f"attn_output={protect}", f"ffn_down={protect}"]
     return flags, cq
 


### PR DESCRIPTION
Grok's policy protects attn v/o; the recipe crushed attn_v, which cost KLD on MoE (dense had slack and won anyway). Single attributable change: protect attn_v/k on the MoE branch only (dense recipe untouched — shipped 7B/14B).

Measured Qwen3-30B-A3B, KLD vs Q6_K base, 145 chunks:
  old mix (attn crushed): PPL 8.99  MeanKLD 0.371  top-1 75.48%  -> LOST KLD
  mix-v2 (attn protected): PPL 8.57  MeanKLD 0.310  top-1 77.81% -> WINS all
vs uniform IQ1_KT (9.01 / 0.360 / 75.47%) at 7.02GB (+6.9%, in band).

Two canonical recipes now: THE dense recipe (locked, 7B/14B) + THE MoE recipe (locked here). automap picks by is_moe. Three-model board complete.