### PR TITLE
pollard-bench --coherence: loop gate (sampling-fixable vs below-floor)

### DIFF
--- a/skills/pollard/SKILL.md
+++ b/skills/pollard/SKILL.md
@@ -34,6 +34,10 @@ drive a path yourself or understand what `pollard` chose.
 > - **Just make the model:** `pollard --gguf model.gguf --run` (one model, no eval).
 > - **Reproduce our gold-card numbers:** add `--benchmark`, or score an existing model with the
 >   drop-in **`pollard-bench --gguf model.gguf --ref f16.gguf`** (PPL + KLD + top-1; `--vs` for head-to-head).
+> - **If a build LOOPS on free-gen:** `pollard-bench --gguf model.gguf --coherence` runs the gate —
+>   generates, detects loops, sweeps sampling, and returns **PASS** (+the sampling to ship on the card)
+>   or **BELOW-FLOOR** (loops under every sampling → NOT a sampling problem; bump `--body` one tier and
+>   rebuild). `--quick` is a fast one-prompt post-build sanity. Sampling-first ALWAYS before a tier change.
 >
 > Never run the benchmark or the sensitivity sweep as part of a plain build — that's the
 > mistake that turned a minutes-long shrink into a 3-hour run. See `benchmarks/README.md`.

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -108,6 +108,33 @@ def test_mla_tensors_need_imatrix():
         assert not A._NEEDS_IMATRIX.search(nm), f"{nm} is a norm, must NOT be flagged"
 
 
+# ---- coherence-gate loop detector (pure heuristic; the real mix failures vs coherent Q8) ------
+def test_loop_detector():
+    import pollard_bench as B
+    loops = [
+        "as big as the " * 15,                                              # phrase loop (the 1-bit mix)
+        "Sg" * 60,                                                          # char loop ('SgSgSg...')
+        "The largest planet in our solar system is the largest planet in our solar system. " * 6,
+        "Planet of France and Planet of France " * 8,
+    ]
+    for t in loops:
+        is_loop, m, why = B.detect_loop(t)
+        assert is_loop, f"should flag loop: {t[:40]!r} -> {why}"
+    coherent = [
+        "The largest planet in our solar system is Jupiter. There are eight planets: Mercury, "
+        "Venus, Earth, Mars, Jupiter, Saturn, Uranus, and Neptune, each orbiting the sun.",
+        "def fib(n):\n    if n == 0:\n        return 0\n    elif n == 1:\n        return 1\n    else:\n"
+        "        return fib(n-1) + fib(n-2)\n\nfor i in range(10):\n    print(fib(i))",
+        "Photosynthesis is how green plants convert sunlight, water, and carbon dioxide into "
+        "glucose and oxygen, using chlorophyll in their leaves to capture the light energy.",
+    ]
+    for t in coherent:
+        is_loop, m, why = B.detect_loop(t)
+        assert not is_loop, f"should NOT flag coherent: {t[:40]!r} -> {why} (metric {m})"
+    # too-short output is undecided, not a loop
+    assert not B.detect_loop("Jupiter.")[0]
+
+
 # ---- auto gate-copy wired into automap (no manual imatrix_fix_gate step) ----------------------
 def test_auto_gate_copy():
     import struct, tempfile

--- a/tools/pollard_bench.py
+++ b/tools/pollard_bench.py
@@ -6,6 +6,8 @@ symmetric half of `pollard` (which BUILDS): `pollard` makes the model, `pollard-
     pollard-bench --gguf model.gguf --ref f16.gguf --eval held.txt          # one model, full board
     pollard-bench --gguf pollard.gguf --vs rival.gguf --ref f16.gguf         # HEAD-TO-HEAD (Pareto verdict)
     pollard-bench --gguf model.gguf --eval held.txt                         # PPL only (no --ref -> no KLD)
+    pollard-bench --gguf model.gguf --coherence                             # COHERENCE GATE (loop check + sampling sweep)
+    pollard-bench --gguf model.gguf --coherence --quick                     # fast one-prompt post-build sanity
 
 --ref is the KL reference (f16 ideally; a Q8_0/Q6_K host if f16 won't load — KLD vs a near-lossless
 ref is what the 14B/30B cards use). --vs runs the SAME eval on a competitor's file (AWQ/GPTQ/unsloth/
@@ -15,9 +17,101 @@ quality for fewer GB, or more quality at the same GB), not as a single number.
 Reuses llama-perplexity; no rebuild. This is the opt-in benchmark — a plain `pollard` build never
 runs it (that's the split that stopped a minutes-long shrink from taking hours).
 """
-import argparse, os, re, subprocess, sys
+import argparse, os, re, subprocess, sys, zlib
+from collections import Counter
 
 from pollard_calc import find_llama_bin
+
+
+# ---- coherence gate: separate a sampling-fixable loop from a below-the-floor build -----------
+# The mix sets QUALITY-at-size; sampling is a RUNTIME knob it can't reach. So a build can loop
+# two ways: (a) good build, bad sampling -> a sweep finds coherent settings (ship them); (b) the
+# bit tier is below the model's coherence floor -> it loops under EVERY sampling -> bump a tier.
+# This gate runs the model, detects loops, sweeps sampling, and returns which case it is.
+
+GATE_PROMPTS = [
+    "Paris is the capital of France. The largest planet in our solar system is",
+    "Here is a short explanation of how photosynthesis works:",
+    "# Python function to compute the nth Fibonacci number\ndef fib(n):",
+]
+# tried in order; first config where ALL prompts are loop-free wins. Escalating anti-repetition.
+SAMPLING_CONFIGS = [
+    ("temp0.7/rp1.15", ["--temp", "0.7", "--repeat-penalty", "1.15", "--repeat-last-n", "256",
+                        "--top-k", "40", "--top-p", "0.9"]),
+    ("temp0.6/rp1.18/freq0.6", ["--temp", "0.6", "--repeat-penalty", "1.18", "--repeat-last-n", "320",
+                                "--top-k", "40", "--frequency-penalty", "0.6"]),
+    ("temp0.5/rp1.20/pres0.5", ["--temp", "0.5", "--repeat-penalty", "1.2", "--repeat-last-n", "384",
+                                "--top-k", "30", "--min-p", "0.1", "--presence-penalty", "0.5"]),
+]
+
+
+def detect_loop(text, min_chars=80):
+    """Pure heuristic loop detector. Returns (is_loop, metric, reason). Two stdlib signals:
+      - zlib compression ratio: degenerate repetition (word- OR char-level: 'as big as the ...',
+        'SgSgSg') compresses to almost nothing; a coherent paragraph sits ~0.35-0.6.
+      - distinct-word ratio: unique/total words; collapses toward 0 on a phrase loop.
+    Short outputs (< min_chars) are UNDECIDED -> not a loop (can't judge). Thresholds picked
+    against the real failures this project hit (mix loops) vs the Q8 coherent baselines."""
+    t = (text or "").strip()
+    b = t.encode("utf-8", "ignore")
+    if len(b) < min_chars:
+        return False, 0.0, "too short to judge"
+    comp = len(zlib.compress(b, 6)) / len(b)
+    if comp < 0.18:
+        return True, round(comp, 3), f"compression ratio {comp:.2f} < 0.18 (degenerate repetition)"
+    words = re.findall(r"\S+", t.lower())
+    if len(words) >= 12:
+        distinct = len(set(words)) / len(words)
+        if distinct < 0.35:
+            return True, round(distinct, 3), f"distinct-word ratio {distinct:.2f} < 0.35 (phrase loop)"
+    return False, round(comp, 3), "coherent"
+
+
+def _generate(cli_bin, model, prompt, sampling, ngl, n_predict=80):
+    cmd = ([cli_bin, "-m", model, "-ngl", str(ngl), "-c", "2048", "-n", str(n_predict), "-p", prompt]
+           + sampling)
+    r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    out = r.stdout or ""
+    # llama-cli echoes the prompt then the continuation; keep only the continuation
+    return out.split(prompt, 1)[-1] if prompt in out else out
+
+
+def coherence_gate(cli_bin, model, ngl, quick=False):
+    """Run the model over the gate prompts, sweeping sampling. A config PASSES only if EVERY
+    prompt is loop-free. Returns a verdict dict: PASS (+the winning sampling) or BELOW_FLOOR.
+    quick=True: one prompt, default sampling only (a fast post-build sanity, not the full gate)."""
+    prompts = GATE_PROMPTS[:1] if quick else GATE_PROMPTS
+    configs = SAMPLING_CONFIGS[:1] if quick else SAMPLING_CONFIGS
+    last = []
+    for cfg_name, sampling in configs:
+        rows, looped = [], False
+        for p in prompts:
+            gen = _generate(cli_bin, model, p, sampling, ngl)
+            is_loop, metric, reason = detect_loop(gen)
+            rows.append({"prompt": p.splitlines()[0][:48], "loop": is_loop, "reason": reason,
+                         "sample": gen.strip().replace("\n", " ")[:120]})
+            looped = looped or is_loop
+        last = rows
+        if not looped:
+            return {"verdict": "PASS", "config": cfg_name, "sampling": sampling, "rows": rows}
+    return {"verdict": "BELOW_FLOOR", "config": None, "rows": last}
+
+
+def print_gate(res):
+    print("\n=== coherence gate ===")
+    for r in res["rows"]:
+        print(f"  [{'LOOP' if r['loop'] else 'ok  '}] {r['prompt']:<50} {r['reason']}")
+        if r["loop"]:
+            print(f"         -> {r['sample']}")
+    if res["verdict"] == "PASS":
+        s = " ".join(res["sampling"])
+        print(f"\nVERDICT: PASS — coherent. Ship these sampling defaults on the card:\n  {s}")
+    else:
+        print("\nVERDICT: BELOW FLOOR — loops under EVERY sampling config. This is NOT a sampling\n"
+              "  problem; the bit tier is below the model's coherence floor. Bump the crush one\n"
+              "  tier and rebuild (e.g. --body iq1_kt -> iq2_kt), then re-gate. (Small/sparse\n"
+              "  models hit this; big models clear 1-bit fine — it's a size property.)")
+    return res["verdict"] == "PASS"
 
 
 def _size_gb(p):
@@ -32,7 +126,7 @@ def _ppl_kl(ppl_bin, model, eval_f, base, ngl):
     cmd = [ppl_bin, "-m", model, "-f", eval_f, "-c", "2048", "-ngl", str(ngl)]
     if base:
         cmd += ["--kl-divergence", "--kl-divergence-base", base]
-    r = subprocess.run(cmd, capture_output=True, text=True)
+    r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
     out = r.stdout + r.stderr
     def g(pat):
         m = re.search(pat, out)
@@ -59,7 +153,26 @@ def main():
     ap.add_argument("--ngl", type=int, default=99, help="GPU layers (lower for a model bigger than the GPU)")
     ap.add_argument("--out", help="write a results.json (feeds pollard-scorecard)")
     ap.add_argument("--llama-perplexity", default="llama-perplexity")
+    ap.add_argument("--llama-cli", default="llama-cli", help="generation binary for the coherence gate")
+    ap.add_argument("--coherence", action="store_true",
+                    help="run the COHERENCE GATE: generate over fixed prompts, detect loops, sweep "
+                         "sampling, and report PASS (+the sampling to ship) or BELOW-FLOOR (bump a tier). "
+                         "Runs alone (no --ref/--eval needed); add --ref for the full board too.")
+    ap.add_argument("--quick", action="store_true",
+                    help="with --coherence: fast one-prompt / default-sampling sanity instead of the full sweep.")
     a = ap.parse_args()
+
+    # --- coherence gate (can run standalone: no perplexity bin / eval corpus required) ---
+    if a.coherence or a.quick:
+        if not os.path.exists(a.gguf):
+            sys.exit(f"file not found: {a.gguf}")
+        cli_bin = find_llama_bin(a.llama_cli)
+        if not cli_bin:
+            sys.exit("llama-cli not found — build llama.cpp/ik_llama.cpp or pass --llama-cli.")
+        res = coherence_gate(cli_bin, a.gguf, a.ngl, quick=a.quick)
+        passed = print_gate(res)
+        if not a.ref:                      # gate-only invocation -> done (exit code reflects verdict)
+            sys.exit(0 if passed else 2)
 
     ppl_bin = find_llama_bin(a.llama_perplexity)
     if not ppl_bin:
@@ -76,7 +189,7 @@ def main():
         print(f"[1] KL base logits from {os.path.basename(a.ref)} (ngl {a.ngl}) ...")
         r = subprocess.run([ppl_bin, "-m", a.ref, "-f", a.eval, "-c", "2048",
                             "-ngl", str(a.ngl), "--kl-divergence-base", base],
-                           capture_output=True, text=True)
+                           capture_output=True, text=True, encoding="utf-8", errors="replace")
         if not os.path.exists(base) or os.path.getsize(base) == 0:
             sys.exit("could not build KL base logits (ref too big for the GPU? lower --ngl, or use "
                      "a smaller near-lossless --ref like Q6_K).")


### PR DESCRIPTION
The mix sets quality-at-size; sampling is a runtime knob it can't reach, so a build can loop two ways. The gate tells them apart:
- detect_loop: pure zlib-compression + distinct-word heuristic (catches word- and char-level degeneration; coherent text incl. code passes). Unit-tested.
- coherence_gate: generate over fixed prompts, sweep escalating anti-repetition sampling; PASS at the first loop-free config (ship that sampling on the card), or BELOW_FLOOR when it loops under every config (bump --body one tier).
- --coherence runs it standalone (no ref/eval); --quick = one-prompt sanity.
- UTF-8 decode on all subprocess calls (Windows model output has non-cp1252 bytes).

Validated live: 2-bit DeepSeek-V2-Lite mix -> PASS. 10/10 tests.