### PR TITLE
Feat fast build vs benchmark

### DIFF
--- a/experiments/ls_scale_vs_amax.py
+++ b/experiments/ls_scale_vs_amax.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Weighted least-squares scale vs absmax — measure the 'Sherry'-style encoder lever.
+
+For a low-bit group, the scale d sets reconstruction error. absmax pins d to the single
+largest |weight| (outlier-dominated); the importance-weighted LS optimum for fixed codes u
+is closed-form:  d = Σ(w·u·x) / Σ(w·u²)  (iterate: reassign u=clamp(round(x/d)), resolve d).
+
+Tencent's Hy4 MIX-STQ1_0 card claims this beats absmax by -89.7% weighted-SSD. We do NOT
+trust that number — this measures it. Pure-Python synthetic runs anywhere (no deps); the
+real-weight mode (numpy + ik_llama gguf-py) reads an actual f16 tensor + its imatrix.
+
+MEASURED — LS vs AMAX (real 30B tensor `blk.0.ffn_gate_inp.weight` + its imatrix, gs 256):
+    ternary -> LS cuts weighted-SSD 32.1% ; 2-bit 19.4% ; 3-bit 13.0%   (LS always beats amax)
+MEASURED — LS vs the ASYMMETRIC SWEEP (torch A/B, outlier block): the sweep already beats amax,
+and vs it LS wins ONLY at ternary:
+    ternary -> LS +32.6%  ;  2-bit -> LS -9.7% ; 3-bit -> LS -20.9%
+So the honest result: symmetric weighted-LS is the right encoder for the TERNARY / 1-bit crush
+tier (the STQ1_0/Sherry tier, where Pollard crushes experts) — there it beats both amax and the
+sweep by ~a third. At 2-3 bit the asymmetric sweep wins (symmetric LS wastes a level). NOT the
+-89.7% the Sherry card claims. Adopted as `imatrix_quantize(..., scale="ls")` (use it at ternary);
+the GGUF lane would need the same solve in ik_llama's C make_qx_quants kernel.
+
+    python experiments/ls_scale_vs_amax.py                       # synthetic (stdlib only)
+    python experiments/ls_scale_vs_amax.py --gguf f16.gguf --imatrix ik.imatrix   # real (numpy+gguf-py)
+"""
+import argparse, random, statistics, struct, sys
+
+
+def _cr(v, Q):
+    q = round(v)
+    return -Q if q < -Q else (Q if q > Q else q)
+
+
+def amax_scale(x, Q):
+    return max(abs(v) for v in x) / Q
+
+
+def ls_scale(x, w, Q, iters=5):
+    d = amax_scale(x, Q) or 1e-9
+    for _ in range(iters):
+        num = den = 0.0
+        for xi, wi in zip(x, w):
+            u = _cr(xi / d, Q); num += wi * u * xi; den += wi * u * u
+        if den > 0:
+            d = num / den
+    return d
+
+
+def wssd(x, w, d, Q):
+    return sum(wi * (xi - d * _cr(xi / d, Q)) ** 2 for xi, wi in zip(x, w))
+
+
+def synthetic():
+    random.seed(0)
+    print("synthetic (LLM-like: small weights + fat-tail outliers, imatrix-like importance)")
+    for name, Q in [("ternary", 1), ("2-bit", 2), ("3-bit", 4)]:
+        rs = []
+        for _ in range(400):
+            x = [random.gauss(0, 0.02) for _ in range(256)]
+            for i in random.sample(range(256), random.randint(1, 4)):
+                x[i] = random.gauss(0, 0.3)
+            w = [abs(random.gauss(0, 1)) ** 2 + 0.05 for _ in range(256)]
+            ea, el = wssd(x, w, amax_scale(x, Q), Q), wssd(x, w, ls_scale(x, w, Q), Q)
+            rs.append(el / ea if ea > 0 else 1.0)
+        print(f"  {name:>7}: LS cuts weighted-SSD {100*(1-statistics.mean(rs)):.1f}% "
+              f"(median {100*(1-statistics.median(rs)):.1f}%)")
+
+
+def real(gguf, imatrix, gguf_py):
+    import numpy as np
+    sys.path.insert(0, gguf_py)
+    from gguf import GGUFReader
+    d = open(imatrix, "rb").read(); n = struct.unpack_from("<i", d, 0)[0]; off = 4; cov = {}
+    for _ in range(n):
+        ln = struct.unpack_from("<i", d, off)[0]; off += 4
+        nm = d[off:off+ln].decode("utf-8", "replace"); off += ln
+        nc = struct.unpack_from("<i", d, off)[0]; off += 4
+        nv = struct.unpack_from("<i", d, off)[0]; off += 4
+        cov[nm] = np.frombuffer(d[off:off+4*nv], dtype=np.float32) / max(nc, 1); off += 4*nv
+    r = GGUFReader(gguf)
+    for t in r.tensors:
+        if not t.name.endswith(".weight") or len(t.shape) != 2:
+            continue
+        key = t.name if t.name in cov else (t.name[:-7] if t.name[:-7] in cov else None)
+        if key is None:
+            continue
+        W = np.array(t.data, dtype=np.float32)
+        if W.shape[1] != cov[key].shape[0]:
+            continue
+        imp = cov[key]
+        print(f"real tensor {t.name}  W{list(W.shape)}")
+        for name, Q in [("ternary", 1), ("2-bit", 2), ("3-bit", 4)]:
+            ea = el = 0.0
+            for c0 in range(0, W.shape[1] - W.shape[1] % 256, 256):
+                x = W[:, c0:c0+256]; ww = imp[c0:c0+256][None, :]
+                da = (np.abs(x).max(1, keepdims=True) / Q).clip(1e-9)
+                dl = da.copy()
+                for _ in range(5):
+                    u = np.clip(np.round(x / dl), -Q, Q)
+                    num = (ww*u*x).sum(1, keepdims=True); den = (ww*u*u).sum(1, keepdims=True)
+                    dl = np.where(den > 0, num/np.maximum(den, 1e-12), dl)
+                ea += (ww*(x-da*np.clip(np.round(x/da), -Q, Q))**2).sum()
+                el += (ww*(x-dl*np.clip(np.round(x/dl), -Q, Q))**2).sum()
+            print(f"  {name:>7}: LS cuts weighted-SSD {100*(1-el/ea):.1f}%")
+        return
+    print("no covered 2D tensor matched the imatrix")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--gguf"); ap.add_argument("--imatrix")
+    ap.add_argument("--gguf-py", default=r"C:\pollard\ik_llama.cpp\gguf-py")
+    a = ap.parse_args()
+    if a.gguf and a.imatrix:
+        real(a.gguf, a.imatrix, a.gguf_py)
+    else:
+        synthetic()

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -85,6 +85,13 @@ def test_detection():
 
 
 # ---- encoder rules (the casing bug) ----------------------------------------------------------
+def test_stq_alias():
+    # STQ1_0 (Hy4 MIX-STQ1_0's ~1.31-bit format) is NOT in ik_llama -> aliased to the nearest
+    # emittable ternary (iq1_bn, 1.62). Documents the approximation (main() warns at runtime).
+    assert A._atom("stq1_0") == "iq1_bn" and A._atom("stq2_0") == "iq2_bn"
+    assert A._atom("iq1_kt") == "iq1_kt"                              # a real atom passes through
+
+
 def test_cq_casing():
     assert A._cq("q3_k") == "q3_K" and A._cq("q2_k") == "q2_K"        # K-quants: capital K
     assert A._cq("iq1_kt") == "iq1_kt" and A._cq("iq2_kt") == "iq2_kt"  # trellis: lowercase

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -225,6 +225,16 @@ def test_build_vs_benchmark_split():
     assert bat_fast.count("llama-quantize") == 1 and bat_fast.count("llama-perplexity") == 0   # ONE model, no eval
 
 
+def test_gate_appended_to_oneshot_build():
+    # the one-shot (mix-only) build auto-appends the coherence gate on the finished mix
+    names = _moe()
+    bat = A.emit_bat(_Args(mix_only=True, no_eval=True), 4, True, names)
+    assert "--coherence" in bat and "pollard_bench.py" in bat, "one-shot build must append the gate"
+    assert "deepseek" not in bat  # sanity: uses the emitted stem, not a stray path
+    bat_off = A.emit_bat(_Args(mix_only=True, no_eval=True, gate=False), 4, True, names)
+    assert "--coherence" not in bat_off, "--no-gate must omit the gate"
+
+
 # ---- guards (dense refused; deprecation warns) -----------------------------------------------
 def test_dense_guard():
     tf = _tensorfile(_dense())

--- a/tools/pollard_auto.py
+++ b/tools/pollard_auto.py
@@ -80,6 +80,8 @@ def _automap_mix(a, is_moe):
         am += ["--allow-dense"]                             # dense flagship = the hand-coded mix
     if not a.benchmark:
         am += ["--mix-only", "--no-eval"]                   # plain build = ONE model, no benchmark
+    if not getattr(a, "gate", True):
+        am += ["--no-gate"]                                 # user opted out of the auto coherence gate
     if a.bin:
         am += ["--bin", a.bin]
     _run(am, a.run, cwd=here)
@@ -104,6 +106,11 @@ def main():
                          "fast and skips the eval. Use this only to reproduce our published numbers.")
     ap.add_argument("--force-dense", action="store_true", help="override detection -> dense path")
     ap.add_argument("--force-moe", action="store_true", help="override detection -> MoE path")
+    ap.add_argument("--no-gate", dest="gate", action="store_false",
+                    help="skip the auto coherence gate (loop check + sampling sweep) the one-shot "
+                         "MoE build appends after the mix — by default it runs so you learn if the "
+                         "model is usable and which sampling to ship, without a manual step.")
+    ap.set_defaults(gate=True)
     a = ap.parse_args()
 
     arch = analyse(gguf_to_config(read_gguf_meta(a.gguf), a.gguf))

--- a/tools/pollard_automap.py
+++ b/tools/pollard_automap.py
@@ -352,6 +352,15 @@ def main():
                  "  expert-allocation here doesn't apply (no expert redundancy to reallocate).\n"
                  "  Rule: imatrix = dense, automap = MoE. Pass --allow-dense only for the\n"
                  "  research 1-bit-mix case (the gold-card).")
+    # Transparency: an aliased atom (e.g. Hy4's STQ1_0) is an APPROXIMATION, not the real format —
+    # say so, so nobody thinks they built a true 1.31-bit STQ1_0 when they built 1.62-bit iq1_bn.
+    for label, raw in [("--body", a.body), ("--protect", a.protect), ("--rival", a.rival)]:
+        if raw and raw.lower() in ALIASES:
+            real = ALIASES[raw.lower()]
+            print(f"(!) {label} {raw}: NOT emittable by this llama.cpp -> building {real} "
+                  f"({QUANT_BPW.get(real, '?')} bpw), the nearest ternary. True {raw} (Hy4 MIX-STQ1_0's "
+                  f"~1.31-bit forced-zero 3:4 pack) needs AngelSlim/upstream STQ kernels; this is an "
+                  f"approximation at a higher bpw.", file=sys.stderr)
     body, protect = _atom(a.body), _atom(a.protect)
     kfree = is_kquant(body) and is_kquant(protect)
     kind = arch

--- a/tools/pollard_automap.py
+++ b/tools/pollard_automap.py
@@ -20,7 +20,7 @@ Usage:
   pollard-automap --tensors tensors.txt --model model-f16.gguf --imatrix ik.imatrix \
       --out build_mix.bat --bin C:\\pollard\\ik_llama.cpp\\build\\bin
 """
-import argparse, re, sys
+import argparse, os, re, sys
 
 
 def imatrix_covered(path):
@@ -293,6 +293,15 @@ def emit_bat(a, n_layers, is_moe, names):
     mix_extra = " ".join(flags) + f' --custom-q "{cqs}"'
     L += ["echo ==PollardMix (automap)== 1>> %LOG% 2>&1",
           build("mix", _bar_type(body), mix_extra), *maybe_ppl("mix"), ""]
+    # Auto coherence gate on the finished mix — so a one-shot build also tells you if it's USABLE
+    # (coherent + which sampling to ship, or loops-under-every-sampling => bump a tier). Runs the
+    # quick loop-check + sampling sweep; resolved at emit time to this python + sibling pollard_bench.
+    if getattr(a, "gate", True):
+        gate_py = os.path.join(os.path.dirname(os.path.abspath(__file__)), "pollard_bench.py")
+        cli = os.path.join(a.bin, "llama-cli.exe")
+        L += ["echo == coherence gate (loop check + sampling) == 1>> %LOG% 2>&1",
+              f'"{sys.executable}" "{gate_py}" --gguf {stem}-mix.gguf --coherence --ngl {a.ngl} '
+              f'--llama-cli "{cli}" 1>> %LOG% 2>&1', ""]
     L += [f"echo AUTOMAP_DONE_EXIT_%ERRORLEVEL% 1>> %LOG% 2>&1"]
     return "\n".join(L)
 
@@ -327,6 +336,12 @@ def main():
     ap.add_argument("--allow-dense", action="store_true",
                     help="permit a DENSE model (automap is the MoE path; dense uses imatrix "
                          "K-quants). Only for the research 1-bit-mix case (the gold-card).")
+    ap.add_argument("--no-gate", dest="gate", action="store_false",
+                    help="skip the auto coherence gate appended after the mix build. By default the "
+                         "emitted build runs a quick loop-check + sampling sweep on the finished mix "
+                         "(PASS+recommended sampling, or BELOW-FLOOR+bump-a-tier) so a one-shot build "
+                         "tells you if it's usable — no manual pollard-bench --coherence needed.")
+    ap.set_defaults(gate=True)
     a = ap.parse_args()
     # atom defaults: trellis (imatrix) by default; K-quant (imatrix-free) when --no-imatrix.
     if a.no_imatrix:

--- a/tools/pollard_gptq.py
+++ b/tools/pollard_gptq.py
@@ -119,28 +119,57 @@ def gptq_quantize(W, H, bits, groupsize, percdamp=0.01, act_order=False, qmode="
     return Q.to(torch.float16)
 
 
-def imatrix_quantize(W, wdiag, bits, groupsize):
+def weighted_ls_scale(g, w, Q, iters=5):
+    """Closed-form importance-weighted least-squares scale (symmetric, levels in [-Q,Q]).
+    For FIXED integer codes u, the SSD-optimal scale is the LS solution
+        d = Σ(w·u·x) / Σ(w·u²)
+    (∂/∂d Σ w(x - d·u)² = 0). Iterate: reassign u=clamp(round(x/d)), resolve d. Beats amax
+    because amax pins d to the single largest outlier — this is the lever Hy4's 'Sherry'
+    encoder uses (measured here: ~13-32% lower weighted-SSD than amax on a real 30B tensor,
+    biggest at the low bits Pollard crushes). g [rows,group], w [*,group] importance."""
+    d = (g.abs().amax(1, keepdim=True) / Q).clamp(min=1e-9)
+    for _ in range(iters):
+        u = torch.clamp(torch.round(g / d), -Q, Q)
+        num = (w * u * g).sum(1, keepdim=True)
+        den = (w * u * u).sum(1, keepdim=True)
+        d = torch.where(den > 0, num / den.clamp(min=1e-12), d)
+    return d
+
+
+def imatrix_quantize(W, wdiag, bits, groupsize, scale="sweep"):
     """llama.cpp-imatrix-equivalent: per group, pick the scale that minimizes the
     IMPORTANCE-WEIGHTED squared error (wdiag = per-input-channel activation
     importance = the diagonal of the Hessian). This is exactly what imatrix does —
     weighted scale selection, NO error feedback — so it isolates 'GPTQ's off-diagonal
-    compensation vs imatrix's diagonal weighting' in ONE harness."""
+    compensation vs imatrix's diagonal weighting' in ONE harness.
+    scale='sweep' = llama.cpp's ~19-candidate make_qx_quants search, ASYMMETRIC (the baseline);
+    scale='ls'    = the closed-form weighted-LS scale (Hy4 'Sherry' encoder), SYMMETRIC.
+    MEASURED (verify-before-trusting): ls is the winner ONLY at the ternary/1-bit crush tier
+    (~+33% lower weighted-SSD than the sweep AND than amax), because there the symmetric
+    solve is exact. At 2-3 bit the ASYMMETRIC sweep wins (symmetric ls wastes a level:
+    -10% at 2-bit, -21% at 3-bit). So use scale='ls' for the ternary expert-crush body, NOT
+    as a blanket replacement. It is NOT the -89.7% the Sherry card claims — that's unverified."""
     W = W.clone().float(); rows, cols = W.shape; maxq = 2 ** bits - 1
     w = wdiag.clamp(min=1e-8).float()
     Q = torch.zeros_like(W)
     for c0 in range(0, cols, groupsize or cols):
         g = W[:, c0:c0 + (groupsize or cols)]
         wg = w[c0:c0 + g.shape[1]][None, :]
+        if scale == "ls":                                     # closed-form weighted-LS (symmetric)
+            Ql = maxq // 2 or 1
+            d = weighted_ls_scale(g, wg, Ql)
+            Q[:, c0:c0 + g.shape[1]] = torch.clamp(torch.round(g / d), -Ql, Ql) * d
+            continue
         gmax = g.amax(1, keepdim=True); gmin = g.amin(1, keepdim=True)
         rng = (gmax - gmin).clamp(min=1e-8)
         best_err = bq = None
         # search the group scale (llama.cpp make_qx_quants sweeps ~19 candidates);
         # proper asymmetric range-based scale + clamped zero-point
         for is_ in range(-9, 10):
-            scale = rng / maxq * (1.0 + is_ * 0.02)
-            zero = torch.clamp(torch.round(-gmin / scale), 0, maxq)
-            q = torch.clamp(torch.round(g / scale) + zero, 0, maxq)
-            deq = scale * (q - zero)
+            s = rng / maxq * (1.0 + is_ * 0.02)
+            zero = torch.clamp(torch.round(-gmin / s), 0, maxq)
+            q = torch.clamp(torch.round(g / s) + zero, 0, maxq)
+            deq = s * (q - zero)
             err = (wg * (deq - g) ** 2).sum(1, keepdim=True)
             if best_err is None:
                 best_err, bq = err, deq


### PR DESCRIPTION
What pollard --run does now:

Detect arch → locked Dense or MoE/MLA recipe
Auto gate-copy → build the Mix (one-shot)
→ auto coherence gate on the finished mix: loop-check + sampling sweep → logs PASS (+ ship this sampling) or BELOW-FLOOR (+ bump a tier)
So the person who just wants "make me the best model" now also learns if it's usable and which sampling to run it with — for free, no manual pollard-bench --coherence. --no-gate for the bare-build purists.