### PR TITLE
fix: register pollard-probes (script + py-module) — was added unregistered, CI caught it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ pollard-gptq = "pollard_gptq:main"
 pollard-automap = "pollard_automap:main"
 pollard-abliterate = "pollard_abliterate:main"
 pollard-probe = "pollard_probe:main"
+pollard-probes = "pollard_probes:main"
 pollard-scorecard = "pollard_scorecard:main"
 pollard-kl = "pollard_kl:main"
 pollard-lowbit = "pollard_lowbit:main"
@@ -69,5 +70,5 @@ pollard-palette = "pollard_palette:main"
 
 [tool.setuptools]
 package-dir = { "" = "tools" }
-py-modules = ["pollard_auto", "pollard_calc", "pollard_fit", "pollard_run", "pollard_fit_dit", "pollard_experts", "pollard_sensitivity", "pollard_smooth", "pollard_rotate", "pollard_precondition", "pollard_eval", "pollard_health", "pollard_pack", "pollard_prune", "pollard_bench", "pollard_export", "pollard_gptq", "pollard_automap", "pollard_abliterate", "pollard_probe", "pollard_scorecard", "pollard_kl", "pollard_lowbit", "pollard_verify", "pollard_doctor", "pollard_hf_smooth", "pollard_mx", "pollard_mlx", "pollard_exl3", "pollard_calib", "pollard_palette", "pollard_ls", "pollard_workspace",
+py-modules = ["pollard_auto", "pollard_calc", "pollard_fit", "pollard_run", "pollard_fit_dit", "pollard_experts", "pollard_sensitivity", "pollard_smooth", "pollard_rotate", "pollard_precondition", "pollard_eval", "pollard_health", "pollard_pack", "pollard_prune", "pollard_bench", "pollard_export", "pollard_gptq", "pollard_automap", "pollard_abliterate", "pollard_probe", "pollard_probes", "pollard_scorecard", "pollard_kl", "pollard_lowbit", "pollard_verify", "pollard_doctor", "pollard_hf_smooth", "pollard_mx", "pollard_mlx", "pollard_exl3", "pollard_calib", "pollard_palette", "pollard_ls", "pollard_workspace",
     "imatrix_fix_gate"]


### PR DESCRIPTION
pollard-probes (script + py-module) — was added unregistered, CI caught it