### PR TITLE
Feat spark2 5 onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,25 @@ The most valuable contribution right now is **data**: run the harnesses in
 curve and your hardware profile. Second most valuable: `pollard-fit` results —
 what you built, for what RAM budget, and how it ran.
 
+## Onboarding a new architecture (help Pollard scale)
+
+Found a model Pollard doesn't recognize yet (a new `model_type` / custom code)?
+`pollard-onboard` does the audit for you and writes a PR-ready contribution — so
+the next person's model of that family one-shots:
+
+```bash
+pollard-onboard --model <hf-repo-or-dir> --contribute
+# -> prints the arch audit (tensor coverage, flags, verdict) and writes
+#    onboarding/<model_type>.md, then shows the exact git + gh commands to PR it.
+```
+
+Fill in the per-lane "works?" rows after you actually build (and `pollard-verify`)
+each lane, then open the PR. That contribution — even just the findings and which
+lanes worked — is what expands Pollard's arch coverage. See
+`notes/custom-arch-onboarding.md` for the full playbook.
+
+## Code
+
 For code: keep tools stdlib-only where possible, keep every measured claim
 attached to something reproducible, and if you used an AI assistant heavily,
 say so in the PR — assisted is fine, unreviewed is not (same policy as

--- a/README.md
+++ b/README.md
@@ -479,6 +479,8 @@ outputs default into the [workspace](#where-your-builds-go--the-workspace) unles
 | `pollard-run` | Measured expert placement for llama.cpp (RAM-streaming runtime) |
 | `pollard-calib` | Multi-domain calibration corpus (Calib 3.0) |
 | `pollard-ls` | List your workspace builds — lane, bpw, size, PPL, verified✓ |
+| `pollard-card` | Generate the standard HF model card from a build's manifest (every PollardWeights repo matches) |
+| `pollard-onboard` | Audit a new/custom architecture and emit a PR-ready contribution (`--contribute`) — scales arch coverage |
 | `install.sh` | Builds the llama.cpp runtime (Metal on macOS + RPC backend) so the chain runs end-to-end; Pollard builds are standard GGUFs — the whole llama.cpp ecosystem is their runtime |
 
 ## Roadmap

--- a/notes/custom-arch-onboarding.md
+++ b/notes/custom-arch-onboarding.md
@@ -5,6 +5,13 @@ Most models are a known arch (llama/qwen/mistral/mixtral/deepseek/glm) and one-s
 pointing at its own `modeling_*.py` — needs a short, GENERIC onboarding. This is the playbook, written
 against the first one we did: **Spark-X2.5-4B** (`Spark2_5ForCausalLM`, XHToken).
 
+## The one command: `pollard-onboard`
+This whole audit is automated — `pollard-onboard --model <repo-or-dir>` pulls the config + tensor names,
+checks coverage against Pollard's matchers, flags custom features, and prints a verdict
+(READY / LIKELY-READY / NEEDS-ONBOARDING). Add `--contribute` and it writes a PR-ready
+`onboarding/<model_type>.md` + the exact git/gh steps to submit it, so each onboarding grows the tool.
+The rest of this doc is what that tool checks (and what to do when it says NEEDS-ONBOARDING).
+
 ## Rule: audit the real tensor names first
 Don't guess from the arch name. Pull the actual names and decide from them:
 

--- a/notes/custom-arch-onboarding.md
+++ b/notes/custom-arch-onboarding.md
@@ -1,0 +1,56 @@
+# Onboarding a custom architecture (the Spark2_5 case)
+
+Most models are a known arch (llama/qwen/mistral/mixtral/deepseek/glm) and one-shot with no work. A
+**custom architecture** — its `config.json` has `model_type` set to something new and an `auto_map`
+pointing at its own `modeling_*.py` — needs a short, GENERIC onboarding. This is the playbook, written
+against the first one we did: **Spark-X2.5-4B** (`Spark2_5ForCausalLM`, XHToken).
+
+## Rule: audit the real tensor names first
+Don't guess from the arch name. Pull the actual names and decide from them:
+
+    curl -sL https://huggingface.co/<repo>/resolve/main/model.safetensors.index.json \
+      | python -c "import json,sys,re;print(sorted(set(re.sub(r'\.\d+\.','.N.',k) for k in json.load(sys.stdin)['weight_map'])))"
+
+Spark2_5's (290 tensors) came back as:
+
+    model.embedding.weight                         # tied embeddings (no lm_head), NOT embed_tokens
+    model.layers.N.input_layernorm.weight
+    model.layers.N.post_attention_layernorm.weight
+    model.layers.N.self_attn.q_k_v_proj.weight     # FUSED QKV (one tensor)
+    model.layers.N.self_attn.g_proj.weight         # head-wise attention output GATE (sigmoid) — new
+    model.layers.N.self_attn.out_proj.weight
+    model.layers.N.mlp.{gate,up,down}_proj.weight  # standard SwiGLU names (activation is GELU)
+    model.norm.weight
+
+Other custom features (from the modeling code / Grok's read): hybrid attention (3 sliding + 1 full,
+window 512, repeating every 4 layers), layer-dependent RoPE (sliding: partial_rotary 1.0/θ 10000;
+full: 0.25/θ 5e6), dense (no experts), tied embeddings.
+
+## What Pollard already handles generically (no per-arch code)
+The arch-agnostic work pays off here — these needed **no** Spark-specific hacks:
+- **Fused QKV** (`q_k_v_proj`): the `ATTN_PROJ` matcher (`self_attn\.[a-z_]*proj[a-z0-9_]*`) catches it, and
+  a fused tensor is one tensor so there's no "don't split the group" problem.
+- **`out_proj`, standard MLP projs**: matched by `ATTN_PROJ` / `FFN_PROJ`.
+
+## What onboarding added (all GENERIC — helps any future custom arch)
+- **`--trust-remote-code {auto,on,off}`** on `pollard-export` / `-mlx` / `-mx` and the `pollard` one-shot.
+  `auto` reads `config.json` as plain JSON (no code executed) and enables remote code ONLY when an
+  `auto_map` is present. Threaded to `GPTQModel.load`, `llm-compressor oneshot` (`trust_remote_code_model`,
+  tolerated if absent), and `mlx_lm.convert` (tolerated if absent). Shared helper: `pollard_workspace.resolve_trust_remote_code`.
+- **Generic embedding name**: MLX now protects any `*embed*` tensor (Spark's `model.embedding`, not just
+  `embed_tokens`) at high bits.
+- **Attention output gate protected**: `self_attn.*g_proj` is selection-critical (like a router) and is
+  pinned high in the GPTQ dynamic map and MLX plan, at every layer. No-op for arches without it.
+
+## Per-lane support status for Spark2_5
+| Lane | Status |
+|---|---|
+| **GGUF** | ✅ upstream: llama.cpp **PR #27868** (merged ~2026-09-06) adds `spark2_5` (fused QKV, sigmoid gates, hybrid layers, dual RoPE). Build needs a llama.cpp at/after that commit. Then Pollard's imatrix + automap run as usual — verify automap's role map covers the GGUF tensor names it emits. |
+| **GPTQ / MX** | ✅ code-ready (trust_remote_code + gate/embed handling). Needs a run on the CUDA box to confirm the custom modeling loads + quantizes. |
+| **MLX** | ⚠️ code-ready, but MLX conversion needs the arch supported inside `mlx_lm` — a truly custom block may not convert until mlx_lm (or a community port) adds it. Try it; if `convert` errors on the arch, that's an mlx_lm gap, not ours. |
+| **EXL3** | ❌ exllamav3 doesn't know `spark2_5` yet — skip until upstream adds it (don't force a recipe). |
+
+## Verify, always
+Custom code + custom attention means the reconstruction check matters more, not less: gate every build
+with `pollard-verify` (decode-vs-source + end-to-end forward) and, on the served side, `pollard-serve-eval`.
+Never trust a proxy metric.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,10 @@ pollard-exl3 = "pollard_exl3:main"
 pollard-calib = "pollard_calib:main"
 pollard-palette = "pollard_palette:main"
 pollard-serve-eval = "pollard_serve_eval:main"
+pollard-card = "pollard_card:main"
+pollard-onboard = "pollard_onboard:main"
 
 [tool.setuptools]
 package-dir = { "" = "tools" }
 py-modules = ["pollard_auto", "pollard_calc", "pollard_fit", "pollard_run", "pollard_fit_dit", "pollard_experts", "pollard_sensitivity", "pollard_smooth", "pollard_rotate", "pollard_precondition", "pollard_eval", "pollard_health", "pollard_pack", "pollard_prune", "pollard_bench", "pollard_export", "pollard_gptq", "pollard_automap", "pollard_abliterate", "pollard_probe", "pollard_probes", "pollard_scorecard", "pollard_kl", "pollard_lowbit", "pollard_verify", "pollard_doctor", "pollard_hf_smooth", "pollard_mx", "pollard_mlx", "pollard_exl3", "pollard_calib", "pollard_palette", "pollard_ls", "pollard_workspace",
-    "pollard_serve_eval", "imatrix_fix_gate"]
+    "pollard_serve_eval", "pollard_card", "pollard_onboard", "imatrix_fix_gate"]

--- a/tools/pollard_auto.py
+++ b/tools/pollard_auto.py
@@ -209,16 +209,17 @@ def _emit_nongguf(a):
     out = a.output or (os.path.basename(hf_dir.rstrip("/\\")) + f"-Pollard-{a.format.upper()}")
     here = os.path.dirname(os.path.abspath(out)) or "."
 
+    trc = ["--trust-remote-code", a.trust_remote_code]     # custom-arch passthrough (Spark2_5 etc.)
     if a.format == "gptq":
         calib = _ensure_calib_text(a, here)
         sens = _ensure_sensitivity(a, hf_dir, calib, here)
-        cmd = ["pollard-export", "--model", hf_dir, "--calib", calib, "--out", out]
+        cmd = ["pollard-export", "--model", hf_dir, "--calib", calib, "--out", out] + trc
         if sens:
             cmd += ["--sensitivity", sens]
     elif a.format == "mx":                                  # Blackwell NVFP4 / any-GPU W4A16 (compressed-tensors)
         calib = _ensure_calib_text(a, here)                # NVFP4 activation scales need calibration
         sens = _ensure_sensitivity(a, hf_dir, calib, here)
-        cmd = ["pollard-mx", "--model", hf_dir, "--calib", calib, "--out", out]
+        cmd = ["pollard-mx", "--model", hf_dir, "--calib", calib, "--out", out] + trc
         if sens:
             cmd += ["--sensitivity", sens]
     elif a.format == "exl3":
@@ -228,7 +229,7 @@ def _emit_nongguf(a):
     else:                                                   # mlx (Apple) — measured 4/8 mix; smoothing N/A
         calib = _ensure_calib_text(a, here)                # only for the probe's held-out eval corpus
         sens = _ensure_sensitivity(a, hf_dir, calib, here)
-        cmd = ["pollard-mlx", "--model", hf_dir, "--out", out]
+        cmd = ["pollard-mlx", "--model", hf_dir, "--out", out] + trc
         if sens:
             cmd += ["--sensitivity", sens]
     print(f"   {a.format.upper()} export (Pollard method — smoothing default + measured allocation):")
@@ -276,6 +277,9 @@ def main():
                     help="skip the auto sensitivity probe on the gptq/mlx/mx lanes (falls back to uniform "
                          "allocation). By default the one-shot measures allocation (pollard-probe) — the gold path.")
     ap.set_defaults(measure=True)
+    ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
+                    help="run a model's own modeling code for custom archs (Spark2_5 etc.); 'auto' enables "
+                         "it only when config.json declares an auto_map. Passed through to the export lanes.")
     ap.add_argument("--imatrix", help="importance matrix (auto-generated from Calib 3.0 if omitted)")
     ap.add_argument("--calib", help="calibration corpus for auto-imatrix (else Calib 3.0 auto-built)")
     ap.add_argument("--ngl", default="99", help="GPU layers for auto-imatrix (lower for a big model)")

--- a/tools/pollard_auto.py
+++ b/tools/pollard_auto.py
@@ -144,13 +144,15 @@ def _resolve_hf(a):
     """A local HF dir is used as-is; a repo id is downloaded (snapshot) so users can point at either.
     Opt-in --abliterate/--smooth transforms are applied here so every lane inherits them."""
     if os.path.isdir(a.hf):
-        return _precondition_hf(a, a.hf)
+        a._hf_dir = _precondition_hf(a, a.hf)
+        return a._hf_dir
     local = os.path.join(os.path.abspath(a.output or "."), a.hf.split("/")[-1])
     print(f"   fetch HF repo: huggingface-cli download {a.hf} --local-dir {local}")
     if a.run:
         from huggingface_hub import snapshot_download
         local = snapshot_download(a.hf, local_dir=local)
-    return _precondition_hf(a, local)
+    a._hf_dir = _precondition_hf(a, local)
+    return a._hf_dir
 
 
 def _hf_to_gguf(a):
@@ -365,11 +367,19 @@ def main():
     # is the flagship mix — no manual calib/fit/calc step. --no-auto-imatrix opts back to ladder-only.
     if not a.imatrix and a.auto_imatrix:
         a.imatrix = _ensure_imatrix(a)
+    # MEASURED allocation for the ladder too (not just uniform K-quants): if we have the HF weights
+    # (came from --hf) and no profile was given, auto-probe one — same gold lever as the export lanes.
+    hf_dir = getattr(a, "_hf_dir", None)
+    if hf_dir and not a.sensitivity and a.measure:
+        here = os.path.dirname(os.path.abspath(a.gguf)) or "."
+        calib = a.calib or os.path.join(here, "pollard_calib.txt")
+        a.sensitivity = _ensure_sensitivity(a, hf_dir, calib, here)
     cmd = ["pollard-fit", "--gguf", a.gguf, "--ram", str(a.ram)]
     if a.imatrix: cmd += ["--imatrix", a.imatrix]
+    if a.sensitivity: cmd += ["--sensitivity", a.sensitivity]   # measured per-layer allocation
     if a.out: cmd += ["--out", a.out]
     if not a.run: cmd += ["--plan-only"]
-    print("   1) the K-quant ladder (fits your RAM budget):")
+    print("   1) the K-quant ladder (measured allocation, fits your RAM budget):")
     _run(cmd, a.run)
     if a.imatrix:
         print(f"   2) the {flagship} mixed-precision flagship (automap trellis mix):")

--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""pollard-card — generate the STANDARD Hugging Face model card for a Pollard build, so every
+published PollardWeights repo looks identical: same frontmatter, same method section, same
+results table, same run instructions. Data-driven from the workspace manifest (what the build
+recorded) + the base model's config, so it's never hand-written and never drifts.
+
+  pollard-card --model openbmb/MiniCPM5-2B --out README.md         # all lanes recorded for this model
+  pollard-card --model <base> --lane gguf --out README.md          # just one lane's repo
+  pollard-card --model <base> --scorecard scorecard.md --out README.md   # embed the gold-card board
+
+Reads POLLARD_HOME's manifest (pollard-ls data) for the size/bpw/ppl/verified of each build. Pass
+--params / --license / --base-model to override or fill what the config doesn't carry. --upload pushes
+the card to a HF repo (needs `huggingface-cli login` or HF_TOKEN)."""
+import argparse
+import json
+import os
+import sys
+
+LANE_RUN = {
+    "gguf": "```bash\n# llama.cpp / Ollama / LM Studio — it's a standard GGUF\nllama-cli -m {file} -p \"Hello\"\n```",
+    "gptq": "```bash\nvllm serve {repo} --quantization gptq\n```",
+    "mx":   "```bash\nvllm serve {repo}   # compressed-tensors (NVFP4 on Blackwell / W4A16 any GPU)\n```",
+    "mlx":  "```bash\nmlx_lm.generate --model {repo} --prompt \"Hello\"\n```",
+    "exl3": "```bash\n# exllamav3 / TabbyAPI\n```",
+}
+LANE_NAME = {"gguf": "GGUF (llama.cpp)", "gptq": "GPTQ (vLLM/SGLang)",
+             "mx": "compressed-tensors (Blackwell NVFP4 / any-GPU W4A16)",
+             "mlx": "MLX (Apple Silicon)", "exl3": "EXL3 (exllamav3)"}
+
+
+def base_config(model_id):
+    """Best-effort read of the base model's config for frontmatter (params/arch/license)."""
+    try:
+        if os.path.isdir(model_id):
+            return json.load(open(os.path.join(model_id, "config.json")))
+        from huggingface_hub import hf_hub_download
+        return json.load(open(hf_hub_download(model_id, "config.json")))
+    except Exception:
+        return {}
+
+
+def load_builds(model_id, lane=None):
+    """Pull this model's recorded builds from the workspace manifest (name/lane/tag/bpw/ppl/size/verified)."""
+    try:
+        import pollard_workspace as ws
+        builds = ws.read_manifest(model_id).get("builds", [])
+    except Exception:
+        builds = []
+    if lane:
+        builds = [b for b in builds if b.get("lane") == lane]
+    return builds
+
+
+def frontmatter(base_model, license_, tags, pipeline, library):
+    lines = ["---",
+             f"base_model: {base_model}" if base_model else None,
+             f"license: {license_}" if license_ else None,
+             f"pipeline_tag: {pipeline}" if pipeline else None,
+             f"library_name: {library}" if library else None,
+             "quantized_by: PollardWeights",
+             "tags:",
+             "  - pollard-weights", "  - quantized", "  - measured-allocation"]
+    lines += [f"  - {t}" for t in tags]
+    lines.append("---")
+    return "\n".join(l for l in lines if l is not None)
+
+
+def results_table(builds):
+    if not builds:
+        return "_No builds recorded yet in the workspace manifest._"
+    rows = ["| Lane | Variant | bpw | Size | PPL | Verified |", "|---|---|---|---|---|---|"]
+    try:
+        import pollard_workspace as ws
+        human = ws.human
+    except Exception:
+        human = lambda n: (f"{n/1e9:.1f}GB" if n else "-")
+    for b in sorted(builds, key=lambda x: (x.get("lane", ""), x.get("bpw") or 0)):
+        size = human(b.get("bytes")) if b.get("bytes") else "-"
+        rows.append("| {lane} | {name} | {bpw} | {size} | {ppl} | {v} |".format(
+            lane=LANE_NAME.get(b.get("lane"), b.get("lane", "-")),
+            name=b.get("tag") or b.get("name", "-"),
+            bpw=b.get("bpw") if b.get("bpw") is not None else "-",
+            size=size,
+            ppl=b.get("ppl") if b.get("ppl") is not None else "-",
+            v="✅" if b.get("verified") else "—"))
+    return "\n".join(rows)
+
+
+def run_section(builds):
+    lanes = sorted({b.get("lane") for b in builds if b.get("lane")}) or ["gguf"]
+    out = []
+    for ln in lanes:
+        ex = next((b for b in builds if b.get("lane") == ln), {})
+        snippet = LANE_RUN.get(ln, "").format(file=ex.get("name", "model.gguf"),
+                                              repo="PollardWeights/" + (ex.get("name") or "model"))
+        out.append(f"**{LANE_NAME.get(ln, ln)}**\n\n{snippet}")
+    return "\n\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0],
+                                 formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
+    ap.add_argument("--model", required=True, help="base model id or dir (for title/frontmatter/config)")
+    ap.add_argument("--lane", help="only this lane's builds (else all recorded lanes)")
+    ap.add_argument("--out", default="README.md", help="output card path (default README.md)")
+    ap.add_argument("--scorecard", help="a pollard-scorecard .md to embed (the gold-card board)")
+    ap.add_argument("--base-model", help="override base_model in the frontmatter")
+    ap.add_argument("--license", dest="license_", help="override license (else from base config)")
+    ap.add_argument("--params", help="human param count for the title, e.g. 2.5B")
+    ap.add_argument("--upload", help="HF repo id to push the card to (needs HF login / HF_TOKEN)")
+    a = ap.parse_args()
+
+    cfg = base_config(a.model)
+    base_model = a.base_model or a.model
+    lic = a.license_ or cfg.get("license") or "apache-2.0"
+    arch = (cfg.get("architectures") or ["?"])[0]
+    pipeline = "text-generation"
+    tags = []
+    if cfg.get("model_type"):
+        tags.append(cfg["model_type"])
+    builds = load_builds(a.model, a.lane)
+
+    name = os.path.basename(str(a.model).rstrip("/"))
+    title = f"{name} — Pollard" + (f" ({a.params})" if a.params else "")
+    parts = [frontmatter(base_model, lic, tags, pipeline, "gguf" if any(b.get("lane") == "gguf" for b in builds) else "transformers")]
+    parts.append(f"# {title}\n")
+    parts.append("[![Pollard Weights](https://img.shields.io/badge/quantized%20by-Pollard%20Weights-6E56CF)]"
+                 "(https://github.com/WestWaters/pollard-weights)\n")
+    parts.append(f"Measured-allocation quantization of [`{base_model}`](https://huggingface.co/{base_model}) "
+                 "with [Pollard Weights](https://github.com/WestWaters/pollard-weights) — bits allocated by "
+                 "**measured KL sensitivity** under a size budget, not a uniform crush.\n")
+    parts.append("## Method\n\n"
+                 "- **Measured allocation** — per-layer sensitivity decides which tensors stay high and which "
+                 "are crushed (imatrix for GGUF; a measured probe for the export lanes).\n"
+                 "- **Preconditioning** — SmoothQuant on the low-bit lanes so massive-activation channels don't "
+                 "collapse the quantizer.\n"
+                 "- **Calibration** — Pollard's Calib 3.0 multi-domain corpus.\n"
+                 "- **Verified** — every build is gated by real reconstruction (`pollard-verify`), never a proxy "
+                 "metric.\n")
+    parts.append("## Variants in this repo\n\n" + results_table(builds) + "\n")
+    parts.append("## Run it\n\n" + run_section(builds) + "\n")
+    if a.scorecard and os.path.exists(a.scorecard):
+        parts.append("## Benchmark scorecard\n\n" + open(a.scorecard, encoding="utf-8").read() + "\n")
+    parts.append("## Reproduce\n\n```bash\npip install pollard-weights\n"
+                 f"pollard --hf {base_model} --format <gguf|gptq|mlx|exl3|mx> --run\n```\n")
+    parts.append("---\n_Card generated by `pollard-card` — every PollardWeights repo uses the same template._")
+    card = "\n".join(parts) + "\n"
+
+    open(a.out, "w", encoding="utf-8").write(card)
+    print(f"wrote model card -> {a.out}  ({len(builds)} build(s) listed)")
+    if a.upload:
+        try:
+            from huggingface_hub import HfApi
+            HfApi().upload_file(path_or_fileobj=a.out, path_in_repo="README.md",
+                                repo_id=a.upload, repo_type="model")
+            print(f"uploaded card -> https://huggingface.co/{a.upload}")
+        except Exception as e:
+            sys.exit(f"upload failed ({e}); is HF_TOKEN set / are you logged in? Card still written to {a.out}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pollard_exl3.py
+++ b/tools/pollard_exl3.py
@@ -161,8 +161,8 @@ def main():
     try:
         import pollard_workspace as ws
         ws.record_build(a.model, "exl3", a.out, tag=f"{a.bpw}bpw", bpw=a.bpw)
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"   (warning: could not record build to the workspace manifest: {e})")
     print(f"wrote EXL3 model -> {a.out}\n  run:  exllamav3 / TabbyAPI loads {a.out}"
           f"\n  VERIFY:  pollard-verify --model {a.out} --source {a.model} --end-to-end")
 

--- a/tools/pollard_export.py
+++ b/tools/pollard_export.py
@@ -20,7 +20,7 @@ Hard runtime constraints baked in (verified Aug 2026):
         --calib calib.txt --out ./Qwen2.5-7B-Instruct-Pollard-GPTQ
     # then: vllm serve ./...-Pollard-GPTQ --quantization gptq
 """
-import argparse, json, re, sys
+import argparse, json, os, re, sys
 import pollard_workspace as ws
 
 HIGH, LOW = 8, 4                       # Marlin supports only these
@@ -34,7 +34,7 @@ def detect_moe(model_id, layers_hint=0):
     num_experts / Mixtral num_local_experts / DeepSeek n_routed_experts)."""
     try:
         from transformers import AutoConfig
-        cfg = AutoConfig.from_pretrained(model_id)
+        cfg = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
         n = getattr(cfg, "num_hidden_layers", 0) or layers_hint
         moe = any(getattr(cfg, k, 0) for k in
                   ("num_experts", "num_local_experts", "n_routed_experts"))
@@ -43,13 +43,16 @@ def detect_moe(model_id, layers_hint=0):
         return False, layers_hint
 
 
+resolve_trust_remote_code = ws.resolve_trust_remote_code   # shared across every export lane
+
+
 def detect_mla(model_id):
     """True if the model uses Multi-head Latent Attention (DeepSeek-V2/V3, GLM-4.5/5.3) — its
     attention is q_a/q_b/kv_a/kv_b_proj, not q/k/v_proj. ATTN_PROJ matches both; this is only
     for the user-facing note. Detected from the low-rank KV config field."""
     try:
         from transformers import AutoConfig
-        cfg = AutoConfig.from_pretrained(model_id)
+        cfg = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
         return getattr(cfg, "kv_lora_rank", None) is not None
     except Exception:
         return False
@@ -85,6 +88,9 @@ def dynamic_config(alloc):
     hot groups. q/k/v+o (or MLA's a/b projections) share the attn bit; gate/up+down share the
     ffn bit (fused-safe). Projection names are matched arch-agnostically (see ATTN_PROJ/FFN_PROJ)."""
     dyn = {}
+    # Head-wise attention output gate (Spark2_5 `self_attn.g_proj`): selection-critical, always high.
+    # No-op for arches without it. Placed first so it holds regardless of per-layer attn allocation.
+    dyn[r".*\.self_attn\.[a-z_]*g_proj"] = {"bits": HIGH}
     for i, g in alloc.items():
         if g["attn"] == HIGH:
             dyn[rf".*\.layers\.{i}\.{ATTN_PROJ}"] = {"bits": HIGH}
@@ -172,6 +178,9 @@ def main():
     ap.add_argument("--hot-frac", type=float, default=0.35, help="fraction of layers kept at 8-bit")
     ap.add_argument("--group-size", type=int, default=128)
     ap.add_argument("--uniform", action="store_true", help="plain uniform W4 (for SGLang mixed-bit fragility)")
+    ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
+                    help="run a model's own modeling code (custom archs like Spark2_5). 'auto' enables it "
+                         "only when config.json has an auto_map (default)")
     ap.add_argument("--moe", dest="moe", action="store_true", default=None,
                     help="force the MoE dynamic map (default: auto-detect from config)")
     ap.add_argument("--dense", dest="moe", action="store_false",
@@ -228,7 +237,8 @@ def main():
     calib = [ln.strip() for ln in open(a.calib, encoding="utf-8") if ln.strip()]
     qcfg = QuantizeConfig(bits=LOW, group_size=a.group_size, desc_act=False, sym=True,
                           dynamic=(dyn or None))
-    model = GPTQModel.load(a.model, qcfg)
+    trc = resolve_trust_remote_code(a.model, a.trust_remote_code)
+    model = GPTQModel.load(a.model, qcfg, trust_remote_code=trc)
     model.quantize(calib)
     if not a.out:
         a.out = ws.resolve_out(a.model, "gptq", tag="int4")

--- a/tools/pollard_fit.py
+++ b/tools/pollard_fit.py
@@ -20,6 +20,7 @@ import argparse
 import heapq
 import json
 import math
+import os
 import re
 import subprocess
 import sys
@@ -464,8 +465,8 @@ def main():
         import pollard_workspace as ws
         bpw = round(os.path.getsize(out) * 8.0 / arch["total"], 2) if arch.get("total") else None
         ws.record_build(a.gguf, "gguf", out, tag=base_preset, bpw=bpw)
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"   (warning: could not record build to the workspace manifest: {e})")
     print(f"\ndone: {out}")
     print("run it with stock llama.cpp / Ollama / LM Studio — it is a normal GGUF.")
 

--- a/tools/pollard_mlx.py
+++ b/tools/pollard_mlx.py
@@ -21,7 +21,7 @@ HIGH, LOW = 8, 4
 def detect_moe(model_id, layers_hint=0):
     try:
         from transformers import AutoConfig
-        cfg = AutoConfig.from_pretrained(model_id)
+        cfg = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
         n = getattr(cfg, "num_hidden_layers", 0) or layers_hint
         moe = any(getattr(cfg, k, 0) for k in
                   ("num_experts", "num_local_experts", "n_routed_experts"))
@@ -54,11 +54,13 @@ def bits_for(path, alloc, is_moe, gsize):
     """Per-module bit-width for MLX (returns a {'bits','group_size'} dict, or False to skip).
     Mirrors the Pollard policy: attn follows the attn profile; the FFN/expert body follows ffn;
     MoE router (`.gate`, not `gate_proj`) and shared experts are pinned HIGH; embeddings kept HIGH."""
-    if "embed_tokens" in path or path.endswith("lm_head"):
+    if "embed" in path or path.endswith("lm_head"):    # embed_tokens (llama) OR embedding (Spark2_5, tied)
         return {"bits": HIGH, "group_size": gsize}      # vocab carriers: keep high
     if is_moe and (re.search(r"\.(mlp|block_sparse_moe)\.gate$", path)
                    or "shared_expert" in path):
         return {"bits": HIGH, "group_size": gsize}      # router + shared: selection integrity
+    if "self_attn" in path and path.endswith("g_proj"):  # head-wise attn output gate (Spark2_5): selection-critical
+        return {"bits": HIGH, "group_size": gsize}
     li = layer_of(path)
     if li is None or li not in alloc:
         return {"bits": LOW, "group_size": gsize}
@@ -78,6 +80,9 @@ def main():
     ap.add_argument("--layers", type=int, default=0)
     ap.add_argument("--hot-frac", type=float, default=0.35)
     ap.add_argument("--group-size", type=int, default=64, help="MLX quant group size (default 64)")
+    ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
+                    help="run a model's own modeling code (custom archs); 'auto' = only if config has auto_map. "
+                         "Note: MLX needs the arch supported in mlx_lm to convert a truly custom model.")
     ap.add_argument("--moe", dest="moe", action="store_true", default=None,
                     help="force MoE policy (default: auto-detect)")
     ap.add_argument("--dense", dest="moe", action="store_false", help="force dense policy")
@@ -129,8 +134,15 @@ def main():
     def predicate(path, module, config=None):              # mlx_lm calls with (path, module)
         return bits_for(path, alloc, is_moe, a.group_size)
 
-    convert(a.model, mlx_path=a.out, quantize=True, q_bits=LOW, q_group_size=a.group_size,
-            quant_predicate=predicate)
+    import pollard_workspace as ws
+    trc = ws.resolve_trust_remote_code(a.model, a.trust_remote_code)
+    ckw = dict(mlx_path=a.out, quantize=True, q_bits=LOW, q_group_size=a.group_size, quant_predicate=predicate)
+    try:
+        convert(a.model, trust_remote_code=trc, **ckw)     # newer mlx_lm accepts it
+    except TypeError:
+        if trc:
+            print("   (this mlx_lm lacks trust_remote_code; a truly custom arch may not convert)")
+        convert(a.model, **ckw)
     try:
         import pollard_workspace as ws
         ws.record_build(a.model, "mlx", a.out, tag=f"{LOW}.{HIGH}")

--- a/tools/pollard_mlx.py
+++ b/tools/pollard_mlx.py
@@ -146,8 +146,8 @@ def main():
     try:
         import pollard_workspace as ws
         ws.record_build(a.model, "mlx", a.out, tag=f"{LOW}.{HIGH}")
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"   (warning: could not record build to the workspace manifest: {e})")
     print(f"wrote MLX model -> {a.out}\n"
           f"  run:  mlx_lm.generate --model {a.out} --prompt \"hello\"\n"
           f"  (mixed {LOW}/{HIGH}-bit, Pollard-allocated; runs on Apple Silicon via MLX/Metal.)")

--- a/tools/pollard_mx.py
+++ b/tools/pollard_mx.py
@@ -88,6 +88,9 @@ def main():
     ap.add_argument("--protect-down", action="store_true",
                     help="also keep every down_proj (residual writer) at FP8 — usually worth it at 4-bit")
     ap.add_argument("--layers", type=int, default=0, help="n decoder layers (else read from config)")
+    ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
+                    help="run a model's own modeling code (custom archs like Spark2_5); 'auto' = only if "
+                         "config.json has an auto_map")
     ap.add_argument("--plan-only", action="store_true", help="print the recipe + avg bits, build nothing")
     a = ap.parse_args()
 
@@ -95,7 +98,7 @@ def main():
     if not n_layers:
         try:
             from transformers import AutoConfig
-            n_layers = getattr(AutoConfig.from_pretrained(a.model), "num_hidden_layers", 0)
+            n_layers = getattr(AutoConfig.from_pretrained(a.model, trust_remote_code=True), "num_hidden_layers", 0)
         except Exception:
             n_layers = 0
     sens = {}
@@ -150,10 +153,19 @@ def main():
     cal = ([l for l in open(a.calib, encoding="utf-8", errors="ignore").read().splitlines() if l.strip()]
            if a.calib else None)
     print(f"   emitting via llm-compressor ({len(cal) if cal else 'no'} calib rows) -> {a.out}")
+    trc = ws.resolve_trust_remote_code(a.model, a.trust_remote_code)
+    def _oneshot(**kw):
+        # llm-compressor exposes trust_remote_code as trust_remote_code_model; tolerate older versions
+        try:
+            oneshot(trust_remote_code_model=trc, **kw)
+        except TypeError:
+            if trc:
+                print("   (this llm-compressor lacks trust_remote_code_model; custom arch may not load)")
+            oneshot(**kw)
     if cal:                                        # FP4 activation scales / GPTQ error-feedback need it
-        oneshot(model=a.model, recipe=mods, dataset=cal, output_dir=a.out)
+        _oneshot(model=a.model, recipe=mods, dataset=cal, output_dir=a.out)
     else:                                          # INT weight-only RTN: no calibration set required
-        oneshot(model=a.model, recipe=mods, output_dir=a.out)
+        _oneshot(model=a.model, recipe=mods, output_dir=a.out)
     ws.record_build(a.model, "mx", a.out, tag=f"{a.scheme}-{ab}bpw", bpw=ab)
     print(f"wrote MX checkpoint -> {a.out}\n  run:  vllm serve {a.out}"
           f"\n  VERIFY:  pollard-verify --model {a.out} --source {a.model} --end-to-end")

--- a/tools/pollard_onboard.py
+++ b/tools/pollard_onboard.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""pollard-onboard — audit a NEW model architecture and emit a ready-to-submit contribution.
+
+When a model's `config.json` has a `model_type` Pollard hasn't seen (an `auto_map` = custom code),
+this does the audit-first step automatically: pulls the REAL tensor names, checks them against
+Pollard's arch-agnostic matchers, flags what needs attention (custom gates, embedding names, MoE/MLA
+signals, remote code), and writes a findings report PLUS a filled-in contribution stub you can PR back
+so the next person's model of that family one-shots. That's how Pollard scales — every onboarding feeds
+the tool.
+
+  pollard-onboard --model XHToken/Spark-X2.5-4B                 # audit + print findings
+  pollard-onboard --model <repo-or-dir> --contribute            # also write a PR-ready contribution file
+  pollard-onboard --model <repo-or-dir> --contribute --out onboarding/spark2_5.md
+
+Read-only and network-light (config.json + the safetensors index only). No weights downloaded, no code
+executed. See notes/custom-arch-onboarding.md for the full playbook."""
+import argparse
+import json
+import os
+import re
+import sys
+
+# Pollard's arch-agnostic matchers (kept in sync with pollard_export).
+ATTN_PROJ = r"self_attn\.[a-z_]*proj[a-z0-9_]*"
+FFN_PROJ = r"(?:mlp|block_sparse_moe)(?:\.experts\.\d+)?\.(?:gate|up|down)_proj"
+KNOWN_TYPES = {"llama", "qwen2", "qwen3", "mistral", "mixtral", "gemma", "gemma2", "gemma3",
+               "phi3", "deepseek_v2", "deepseek_v3", "glm4", "glm4_moe", "cohere", "starcoder2"}
+
+
+def _fetch(model_id, fname):
+    if os.path.isdir(model_id):
+        p = os.path.join(model_id, fname)
+        return open(p) if os.path.exists(p) else None
+    try:
+        from huggingface_hub import hf_hub_download
+        return open(hf_hub_download(model_id, fname))
+    except Exception:
+        return None
+
+
+def tensor_patterns(model_id):
+    """Unique per-layer tensor patterns (layer index collapsed to N) from the safetensors index."""
+    f = _fetch(model_id, "model.safetensors.index.json")
+    if not f:
+        return []
+    try:
+        wm = json.load(f).get("weight_map", {})
+    except Exception:
+        return []
+    return sorted(set(re.sub(r"\.\d+\.", ".N.", k) for k in wm))
+
+
+def audit(model_id):
+    cfg = {}
+    f = _fetch(model_id, "config.json")
+    if f:
+        try:
+            cfg = json.load(f)
+        except Exception:
+            pass
+    mtype = cfg.get("model_type", "?")
+    custom = bool(cfg.get("auto_map"))
+    known = mtype in KNOWN_TYPES
+    pats = tensor_patterns(model_id)
+    weight_pats = [p for p in pats if p.endswith(".weight")]
+    findings = {"model": model_id, "model_type": mtype, "arch": (cfg.get("architectures") or ["?"])[0],
+                "custom_code": custom, "known_type": known, "n_tensor_patterns": len(pats)}
+
+    covered, unmatched, flags = [], [], []
+    for p in weight_pats:
+        body = p[:-len(".weight")]
+        if re.search(ATTN_PROJ, body) or re.search(FFN_PROJ, body) or \
+           re.search(r"(input_layernorm|post_attention_layernorm|\bnorm\b|layernorm)", body):
+            covered.append(p)
+        elif "embed" in body or body.endswith("lm_head"):
+            covered.append(p)                                   # vocab carriers (handled generically)
+        else:
+            unmatched.append(p)
+    # heuristic flags for the onboarder
+    if any("self_attn" in p and re.search(r"\bg_proj\b|gate", p) for p in weight_pats):
+        flags.append("attention output GATE present (protect it high — like a router)")
+    if any("q_k_v_proj" in p or "qkv" in p for p in weight_pats):
+        flags.append("FUSED QKV (one tensor — allocate as a single unit)")
+    if any("embedding" in p and "embed_tokens" not in p for p in weight_pats):
+        flags.append("non-standard embedding name (Pollard now matches any *embed*)")
+    if cfg.get("kv_lora_rank") is not None:
+        flags.append("MLA attention (q_a/q_b/kv_a/kv_b) — covered by ATTN_PROJ")
+    if any(cfg.get(k) for k in ("num_experts", "num_local_experts", "n_routed_experts")):
+        flags.append("MoE — use the MoE dynamic map / automap MoE path")
+    if custom:
+        flags.append("custom modeling code — run lanes with --trust-remote-code (auto-detected)")
+    findings.update(covered=len(covered), unmatched=unmatched, flags=flags, patterns=pats)
+    return findings
+
+
+def verdict(f):
+    if f["known_type"] and not f["unmatched"]:
+        return "READY", "known arch, all tensors covered — one-shots as-is."
+    if not f["unmatched"]:
+        return "LIKELY-READY", ("custom code but every tensor maps to Pollard's generic matchers — try the "
+                                "one-shot with --trust-remote-code; verify with pollard-verify.")
+    return "NEEDS-ONBOARDING", f"{len(f['unmatched'])} tensor pattern(s) unmatched — see below."
+
+
+def contribution_md(f, v):
+    lines = [f"# Onboarding: `{f['model_type']}` ({f['arch']})", "",
+             f"- **Example model:** {f['model']}",
+             f"- **Custom code (auto_map):** {'yes — needs --trust-remote-code' if f['custom_code'] else 'no'}",
+             f"- **Verdict:** {v[0]} — {v[1]}", "",
+             "## Tensor patterns", "```", *f["patterns"], "```", ""]
+    if f["flags"]:
+        lines += ["## Flags / features", *[f"- {x}" for x in f["flags"]], ""]
+    if f["unmatched"]:
+        lines += ["## Unmatched tensors (need a mapping)", *[f"- `{x}`" for x in f["unmatched"]],
+                  "", "Suggested: extend the arch-agnostic matcher or add the role mapping in "
+                  "`pollard_export.py` / `pollard_mlx.py`, then re-run `pollard-onboard` until clean.", ""]
+    lines += ["## Per-lane status (fill in after a build)",
+              "| Lane | Works? | Notes |", "|---|---|---|",
+              "| GGUF (llama.cpp) |  | needs converter support for this arch (check upstream PRs) |",
+              "| GPTQ / MX |  | trust_remote_code auto; verify custom load |",
+              "| MLX |  | needs the arch in mlx_lm |",
+              "| EXL3 |  | needs exllamav3 support |", "",
+              "_Generated by `pollard-onboard`. Verify every build with `pollard-verify` before reporting works=yes._"]
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0],
+                                 formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
+    ap.add_argument("--model", required=True, help="HF repo id or local model dir")
+    ap.add_argument("--contribute", action="store_true", help="also write a PR-ready contribution file")
+    ap.add_argument("--out", help="contribution file path (default onboarding/<model_type>.md)")
+    a = ap.parse_args()
+
+    f = audit(a.model)
+    v = verdict(f)
+    print(f"== pollard-onboard :: {a.model}")
+    print(f"   model_type={f['model_type']}  arch={f['arch']}  custom_code={f['custom_code']}  "
+          f"known={f['known_type']}  tensors={f['n_tensor_patterns']}")
+    print(f"   coverage: {f['covered']} matched, {len(f['unmatched'])} unmatched")
+    for fl in f["flags"]:
+        print(f"   • {fl}")
+    if f["unmatched"]:
+        print("   UNMATCHED:")
+        for p in f["unmatched"]:
+            print(f"     - {p}")
+    print(f"\n   VERDICT: {v[0]} — {v[1]}")
+
+    if a.contribute:
+        out = a.out or os.path.join("onboarding", f"{f['model_type']}.md")
+        os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
+        open(out, "w", encoding="utf-8").write(contribution_md(f, v))
+        print(f"\n   contribution written -> {out}")
+        print("   Contribute it back so the next person's model one-shots:")
+        print(f"     git checkout -b onboard-{f['model_type']} && git add {out} && \\")
+        print(f"       git commit -m 'onboard: {f['model_type']} arch findings' && \\")
+        print("       gh pr create --repo WestWaters/pollard-weights --fill")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pollard_workspace.py
+++ b/tools/pollard_workspace.py
@@ -179,3 +179,27 @@ def list_models() -> list:
     if not os.path.isdir(root):
         return []
     return sorted(d for d in os.listdir(root) if os.path.isdir(os.path.join(root, d)))
+
+
+def resolve_trust_remote_code(model_id, mode="auto") -> bool:
+    """Custom architectures (Spark2_5, etc.) ship their own modeling code that transformers must be
+    allowed to run to load them. 'auto' enables it ONLY when the model's config.json declares an
+    `auto_map` (i.e. it actually has custom code) and says so; 'on'/'off' force it. Reads config.json
+    as plain JSON — no code is executed to make the decision. Shared by every export lane."""
+    if mode == "on":
+        return True
+    if mode == "off":
+        return False
+    try:
+        import json
+        if os.path.isdir(model_id):
+            cfg = json.load(open(os.path.join(model_id, "config.json")))
+        else:
+            from huggingface_hub import hf_hub_download
+            cfg = json.load(open(hf_hub_download(model_id, "config.json")))
+        if cfg.get("auto_map"):
+            print("   [trust-remote-code] custom architecture (auto_map) detected — enabling remote code")
+            return True
+        return False
+    except Exception:
+        return False


### PR DESCRIPTION
What's in this PR (the "gap closed" + all the onboarding/publishing work):

Custom-arch onboarding (generic --trust-remote-code + gate/embed handling) — Spark2_5 ready
pollard-card (standard HF card) + pollard-onboard (your contribution flow)
Record gap fixed (the import os bug + surfaced failures)
GGUF measured allocation (auto-probe — the last gap you asked to close)
Gates green (compile, pyproject consistency, 14 tests)
