### PR TITLE
fix(card): match the PollardWeights standard card + install.sh builds…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,25 @@ else
   echo "add to PATH:  export PATH=\"$LLAMA_DIR/build/bin:\$PATH\""
 fi
 
+# 3. ik_llama.cpp — the TRELLIS engine (IQ*_KT / QTIP types) that Pollard's 1-bit-class
+#    FLAGSHIP build needs. Stock llama.cpp (above) covers the K-quant ladder and runs
+#    everywhere; the flagship's IQ1_KT/IQ2_KT quants only build + run with ik_llama.cpp.
+#    Skip with POLLARD_NO_IK=1 (K-quant-only install).
+IK_DIR="${IK_DIR:-$HERE/runtime/ik_llama.cpp}"
+if [ -n "$POLLARD_NO_IK" ]; then
+  echo "ik_llama.cpp: skipped (POLLARD_NO_IK set) — flagship IQ*_KT builds unavailable, K-quants OK"
+elif [ -x "$IK_DIR/build/bin/llama-quantize" ]; then
+  echo "ik_llama.cpp: found at $IK_DIR/build/bin (trellis engine ready)"
+else
+  echo "building ik_llama.cpp (trellis engine for the flagship)…"
+  [ -d "$IK_DIR" ] || git clone --depth 1 https://github.com/ikawrakow/ik_llama.cpp "$IK_DIR"
+  cmake -S "$IK_DIR" -B "$IK_DIR/build" -DCMAKE_BUILD_TYPE=Release -DGGML_RPC=ON $GPU_FLAGS
+  cmake --build "$IK_DIR/build" -j \
+    --target llama-quantize llama-cli llama-imatrix llama-perplexity
+  echo "ik_llama.cpp built at $IK_DIR/build/bin ${GPU_FLAGS:+($GPU_FLAGS)}"
+  echo "for the trellis FLAGSHIP, prefer its binaries:  export PATH=\"$IK_DIR/build/bin:\$PATH\""
+fi
+
 echo
 echo "quickstart:"
 echo "  pollard-calc --model <hf-id> --ram 16          # what CAN this machine do"

--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -1,35 +1,30 @@
 #!/usr/bin/env python3
-"""pollard-card — generate the STANDARD Hugging Face model card for a Pollard build, so every
-published PollardWeights repo looks identical: same frontmatter, same method section, same
-results table, same run instructions. Data-driven from the workspace manifest (what the build
-recorded) + the base model's config, so it's never hand-written and never drifts.
+"""pollard-card — generate the STANDARD PollardWeights Hugging Face model card, so every published
+repo matches: same frontmatter, the shrink-hero + size table, the Available-files table
+(PPL/size/Mean-KLD/notes), usage, errata, and footer. Data-driven from the workspace manifest +
+the base model's config — never hand-written, never drifts.
 
-  pollard-card --model openbmb/MiniCPM5-2B --out README.md         # all lanes recorded for this model
-  pollard-card --model <base> --lane gguf --out README.md          # just one lane's repo
-  pollard-card --model <base> --scorecard scorecard.md --out README.md   # embed the gold-card board
+  pollard-card --model openbmb/MiniCPM5-2B --params 2.5B --out README.md
+  pollard-card --model <base> --builds-from <manifest-key> --results results.json --out README.md
+  pollard-card ... --repo PollardWeights/<Model>-Pollard --upload PollardWeights/<Model>-Pollard
 
-Reads POLLARD_HOME's manifest (pollard-ls data) for the size/bpw/ppl/verified of each build. Pass
---params / --license / --base-model to override or fill what the config doesn't carry. --upload pushes
-the card to a HF repo (needs `huggingface-cli login` or HF_TOKEN)."""
+`--results` (optional) supplies per-file PPL / Mean-KLD / eval string so the files table carries real
+numbers; without it those columns show "—". `--builds-from` reads builds recorded under a different
+manifest key (e.g. the f16 GGUF path). Sizes/bpw come from the manifest."""
 import argparse
 import json
 import os
 import sys
 
-LANE_RUN = {
-    "gguf": "```bash\n# llama.cpp / Ollama / LM Studio — it's a standard GGUF\nllama-cli -m {file} -p \"Hello\"\n```",
-    "gptq": "```bash\nvllm serve {repo} --quantization gptq\n```",
-    "mx":   "```bash\nvllm serve {repo}   # compressed-tensors (NVFP4 on Blackwell / W4A16 any GPU)\n```",
-    "mlx":  "```bash\nmlx_lm.generate --model {repo} --prompt \"Hello\"\n```",
-    "exl3": "```bash\n# exllamav3 / TabbyAPI\n```",
-}
-LANE_NAME = {"gguf": "GGUF (llama.cpp)", "gptq": "GPTQ (vLLM/SGLang)",
-             "mx": "compressed-tensors (Blackwell NVFP4 / any-GPU W4A16)",
-             "mlx": "MLX (Apple Silicon)", "exl3": "EXL3 (exllamav3)"}
+LANE_TAGS = {"gguf": ["gguf", "llama.cpp", "ik_llama.cpp", "trellis", "imatrix"],
+             "gptq": ["gptq", "vllm", "compressed-tensors"],
+             "mx": ["nvfp4", "compressed-tensors", "vllm", "blackwell"],
+             "mlx": ["mlx", "apple-silicon"], "exl3": ["exl3", "exllamav3"]}
+# format size multipliers vs f16 (bytes/param relative to 2.0) — for the shrink size table
+FMT_BPP = {"Q8_0": 1.06, "Q6_K": 0.82, "Q5_K_M": 0.69, "Q4_K_M": 0.58, "NVFP4": 0.53, "IQ4_XS": 0.55}
 
 
 def base_config(model_id):
-    """Best-effort read of the base model's config for frontmatter (params/arch/license)."""
     try:
         if os.path.isdir(model_id):
             return json.load(open(os.path.join(model_id, "config.json")))
@@ -39,115 +34,143 @@ def base_config(model_id):
         return {}
 
 
-def load_builds(model_id, lane=None):
-    """Pull this model's recorded builds from the workspace manifest (name/lane/tag/bpw/ppl/size/verified)."""
+def load_builds(key, lane=None):
     try:
         import pollard_workspace as ws
-        builds = ws.read_manifest(model_id).get("builds", [])
+        builds = ws.read_manifest(key).get("builds", [])
     except Exception:
         builds = []
-    if lane:
-        builds = [b for b in builds if b.get("lane") == lane]
-    return builds
+    return [b for b in builds if (not lane or b.get("lane") == lane)]
 
 
-def frontmatter(base_model, license_, tags, pipeline, library):
-    lines = ["---",
-             f"base_model: {base_model}" if base_model else None,
-             f"license: {license_}" if license_ else None,
-             f"pipeline_tag: {pipeline}" if pipeline else None,
-             f"library_name: {library}" if library else None,
-             "quantized_by: PollardWeights",
-             "tags:",
-             "  - pollard-weights", "  - quantized", "  - measured-allocation"]
-    lines += [f"  - {t}" for t in tags]
-    lines.append("---")
-    return "\n".join(l for l in lines if l is not None)
+def human_gb(nbytes):
+    return f"{nbytes/1e9:.2f} GB" if nbytes else "—"
 
 
-def results_table(builds):
-    if not builds:
-        return "_No builds recorded yet in the workspace manifest._"
-    rows = ["| Lane | Variant | bpw | Size | PPL | Verified |", "|---|---|---|---|---|---|"]
-    try:
-        import pollard_workspace as ws
-        human = ws.human
-    except Exception:
-        human = lambda n: (f"{n/1e9:.1f}GB" if n else "-")
-    for b in sorted(builds, key=lambda x: (x.get("lane", ""), x.get("bpw") or 0)):
-        size = human(b.get("bytes")) if b.get("bytes") else "-"
-        rows.append("| {lane} | {name} | {bpw} | {size} | {ppl} | {v} |".format(
-            lane=LANE_NAME.get(b.get("lane"), b.get("lane", "-")),
-            name=b.get("tag") or b.get("name", "-"),
-            bpw=b.get("bpw") if b.get("bpw") is not None else "-",
-            size=size,
-            ppl=b.get("ppl") if b.get("ppl") is not None else "-",
-            v="✅" if b.get("verified") else "—"))
-    return "\n".join(rows)
+def parse_params_b(params, cfg):
+    if params:
+        s = str(params).upper().replace("B", "").strip()
+        try:
+            return float(s)
+        except ValueError:
+            pass
+    # rough estimate from config if not given
+    h = cfg.get("hidden_size", 0); L = cfg.get("num_hidden_layers", 0); v = cfg.get("vocab_size", 0)
+    return round((12 * L * h * h + 2 * v * h) / 1e9, 2) if h and L else 0.0
 
 
-def run_section(builds):
-    lanes = sorted({b.get("lane") for b in builds if b.get("lane")}) or ["gguf"]
-    out = []
+def frontmatter(base_model, lic, lanes, model_type):
+    tags = ["pollard-weights", "pollard"]
     for ln in lanes:
-        ex = next((b for b in builds if b.get("lane") == ln), {})
-        snippet = LANE_RUN.get(ln, "").format(file=ex.get("name", "model.gguf"),
-                                              repo="PollardWeights/" + (ex.get("name") or "model"))
-        out.append(f"**{LANE_NAME.get(ln, ln)}**\n\n{snippet}")
-    return "\n\n".join(out)
+        tags += LANE_TAGS.get(ln, [ln])
+    if model_type:
+        tags.append(model_type)
+    tags += ["quantized", "mixed-precision", "measured-allocation", "conversational"]
+    seen, uniq = set(), []
+    for t in tags:
+        if t not in seen:
+            seen.add(t); uniq.append(t)
+    lines = ["---", f"license: {lic}", f"base_model: {base_model}", "base_model_relation: quantized",
+             "quantized_by: PollardWeights", "pipeline_tag: text-generation", "language:", "- en", "tags:"]
+    lines += [f"- {t}" for t in uniq]
+    lines.append("---")
+    return "\n".join(lines)
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0],
                                  formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
-    ap.add_argument("--model", required=True, help="base model id or dir (for title/frontmatter/config)")
-    ap.add_argument("--lane", help="only this lane's builds (else all recorded lanes)")
-    ap.add_argument("--out", default="README.md", help="output card path (default README.md)")
-    ap.add_argument("--scorecard", help="a pollard-scorecard .md to embed (the gold-card board)")
-    ap.add_argument("--base-model", help="override base_model in the frontmatter")
-    ap.add_argument("--license", dest="license_", help="override license (else from base config)")
-    ap.add_argument("--params", help="human param count for the title, e.g. 2.5B")
+    ap.add_argument("--model", required=True, help="base model id or dir (title/frontmatter/config)")
+    ap.add_argument("--builds-from", help="workspace manifest key for builds (default: --model)")
+    ap.add_argument("--base-model", help="base_model for the frontmatter (default: --model)")
+    ap.add_argument("--title", help="card title (default: basename of base model)")
+    ap.add_argument("--params", help="param count, e.g. 2.5B (else estimated from config)")
+    ap.add_argument("--license", dest="license_", help="license (else from base config)")
+    ap.add_argument("--lane", help="only this lane's builds")
+    ap.add_argument("--results", help="JSON: {file_or_tag: {ppl, kld, note}} + optional {_eval, _f16_ppl}")
+    ap.add_argument("--repo", help="HF repo id (for ollama/usage lines; default from base name)")
+    ap.add_argument("--out", default="README.md")
     ap.add_argument("--upload", help="HF repo id to push the card to (needs HF login / HF_TOKEN)")
     a = ap.parse_args()
 
-    cfg = base_config(a.model)
+    cfg = base_config(a.base_model or a.model)
     base_model = a.base_model or a.model
     lic = a.license_ or cfg.get("license") or "apache-2.0"
-    arch = (cfg.get("architectures") or ["?"])[0]
-    pipeline = "text-generation"
-    tags = []
-    if cfg.get("model_type"):
-        tags.append(cfg["model_type"])
-    builds = load_builds(a.model, a.lane)
+    mtype = cfg.get("model_type", "")
+    builds = load_builds(a.builds_from or a.model, a.lane)
+    lanes = sorted({b.get("lane") for b in builds if b.get("lane")}) or (["gguf"])
+    name = a.title or os.path.basename(str(base_model).rstrip("/"))
+    repo = a.repo or f"PollardWeights/{name}-Pollard"
+    results = {}
+    if a.results and os.path.exists(a.results):
+        results = json.load(open(a.results))
+    eval_str = results.get("_eval", "")
+    f16_ppl = results.get("_f16_ppl")
 
-    name = os.path.basename(str(a.model).rstrip("/"))
-    title = f"{name} — Pollard" + (f" ({a.params})" if a.params else "")
-    parts = [frontmatter(base_model, lic, tags, pipeline, "gguf" if any(b.get("lane") == "gguf" for b in builds) else "transformers")]
-    parts.append(f"# {title}\n")
-    parts.append("[![Pollard Weights](https://img.shields.io/badge/quantized%20by-Pollard%20Weights-6E56CF)]"
-                 "(https://github.com/WestWaters/pollard-weights)\n")
-    parts.append(f"Measured-allocation quantization of [`{base_model}`](https://huggingface.co/{base_model}) "
-                 "with [Pollard Weights](https://github.com/WestWaters/pollard-weights) — bits allocated by "
-                 "**measured KL sensitivity** under a size budget, not a uniform crush.\n")
-    parts.append("## Method\n\n"
-                 "- **Measured allocation** — per-layer sensitivity decides which tensors stay high and which "
-                 "are crushed (imatrix for GGUF; a measured probe for the export lanes).\n"
-                 "- **Preconditioning** — SmoothQuant on the low-bit lanes so massive-activation channels don't "
-                 "collapse the quantizer.\n"
-                 "- **Calibration** — Pollard's Calib 3.0 multi-domain corpus.\n"
-                 "- **Verified** — every build is gated by real reconstruction (`pollard-verify`), never a proxy "
-                 "metric.\n")
-    parts.append("## Variants in this repo\n\n" + results_table(builds) + "\n")
-    parts.append("## Run it\n\n" + run_section(builds) + "\n")
-    if a.scorecard and os.path.exists(a.scorecard):
-        parts.append("## Benchmark scorecard\n\n" + open(a.scorecard, encoding="utf-8").read() + "\n")
-    parts.append("## Reproduce\n\n```bash\npip install pollard-weights\n"
-                 f"pollard --hf {base_model} --format <gguf|gptq|mlx|exl3|mx> --run\n```\n")
-    parts.append("---\n_Card generated by `pollard-card` — every PollardWeights repo uses the same template._")
-    card = "\n".join(parts) + "\n"
+    pb = parse_params_b(a.params, cfg)
+    f16_gb = pb * 2.0
+    builds_sorted = sorted(builds, key=lambda b: -(b.get("bytes") or 0))
+    smallest = builds_sorted[-1] if builds_sorted else {}
+    small_gb = (smallest.get("bytes") or 0) / 1e9
+    pct = (1 - small_gb / f16_gb) * 100 if f16_gb else 0
+    x = f16_gb / small_gb if small_gb else 0
 
+    # ---- frontmatter + hero
+    out = [frontmatter(base_model, lic, lanes, mtype), "", f"# {name} — Pollard", ""]
+    if f16_gb and small_gb:
+        out += [f"> ### Pollard shrank this model: **{f16_gb:.1f} GB (f16) → {small_gb:.2f} GB** — "
+                f"**{pct:.0f}% smaller, {x:.1f}× down**.",
+                f"> The smallest rung here; larger, higher-fidelity rungs are listed below.", ">",
+                "> | format | this model's size |", "> |---|---:|", f"> | f16 | {f16_gb:.1f} GB |"]
+        for fmt, mult in FMT_BPP.items():
+            if fmt in ("Q8_0", "Q6_K", "Q4_K_M"):
+                out.append(f"> | {fmt} | ~{pb*mult:.1f} GB |")
+        out += [f"> | **PollardMix (this repo's {smallest.get('tag','best')})** | **{small_gb:.2f} GB** |", ""]
+    out += [f"Pollard builds of [{base_model}](https://huggingface.co/{base_model}) made with "
+            "[Pollard Weights](https://github.com/WestWaters/pollard-weights) — a ladder of "
+            "**measured-allocation** quants (bits placed by per-layer sensitivity, not a uniform crush).", ""]
+    if "gguf" in lanes:
+        out += ["**Standard GGUF — runs in stock llama.cpp / ik_llama.cpp, Ollama, LM Studio.** "
+                "Trellis (`IQ*_KT`) files need [ik_llama.cpp](https://github.com/ikawrakow/ik_llama.cpp); "
+                "the K-quants run anywhere.", ""]
+
+    # ---- available files
+    out += [f"## Available files{(' (' + eval_str + ')') if eval_str else ''}", ""]
+    if f16_ppl:
+        out.append(f"_f16 reference PPL {f16_ppl}._\n")
+    out += ["| file | PPL | size | Mean KLD | notes |", "|---|---:|---:|---:|---|"]
+    for b in sorted(builds, key=lambda x: (x.get("bytes") or 0)):
+        r = results.get(b.get("name", ""), results.get(b.get("tag", ""), {}))
+        out.append(f"| `{b.get('name','-')}` | {r.get('ppl','—')} | {human_gb(b.get('bytes'))} | "
+                   f"{r.get('kld','—')} | {r.get('note', b.get('tag',''))} |")
+    if not results:
+        out.append("")
+        out.append("_PPL / Mean-KLD benchmarking pending — sizes and allocation are final._")
+    out.append("")
+
+    # ---- usage
+    ex = min(builds, key=lambda b: (b.get("bytes") or 1e18), default={})
+    out += ["## Usage", ""]
+    if "gguf" in lanes:
+        out += ["```bash", f"llama-cli -m {ex.get('name','model.gguf')} -p \"Explain why the sky is blue.\" --temp 0.7",
+                f"ollama run hf.co/{repo}", "```", ""]
+    if "mlx" in lanes:
+        out += ["```bash", f"mlx_lm.generate --model {repo} --prompt \"Hello\"", "```", ""]
+    if "gptq" in lanes or "mx" in lanes:
+        out += ["```bash", f"vllm serve {repo}", "```", ""]
+
+    # ---- errata + footer
+    out += ["## Errata", ""]
+    if "gguf" in lanes:
+        out.append("- Trellis (`IQ*_KT`) quants need ik_llama.cpp to build/run; K-quants run in any recent llama.cpp.")
+    out += ["- Measured allocation places bits by per-layer sensitivity under a size budget.",
+            "- Single machine; replication invited.", "",
+            "*Built with [Pollard Weights](https://github.com/WestWaters/pollard-weights) — "
+            "frontier models, small hardware, no compromise.*"]
+
+    card = "\n".join(out) + "\n"
     open(a.out, "w", encoding="utf-8").write(card)
-    print(f"wrote model card -> {a.out}  ({len(builds)} build(s) listed)")
+    print(f"wrote model card -> {a.out}  ({len(builds)} file(s), lanes: {','.join(lanes)})")
     if a.upload:
         try:
             from huggingface_hub import HfApi
@@ -155,7 +178,7 @@ def main():
                                 repo_id=a.upload, repo_type="model")
             print(f"uploaded card -> https://huggingface.co/{a.upload}")
         except Exception as e:
-            sys.exit(f"upload failed ({e}); is HF_TOKEN set / are you logged in? Card still written to {a.out}.")
+            sys.exit(f"upload failed ({e}); card still written to {a.out}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
… ik_llama

Published repos weren't matching the existing PollardWeights card standard. Rewrote pollard-card to emit that standard by construction, so every repo matches:
- frontmatter: license, base_model, base_model_relation: quantized, quantized_by, pipeline_tag, language, and the full tag set (pollard-weights/pollard/<lane tags>/<model_type>/quantized/mixed-precision/measured-allocation/conversational)
- shrink-hero line (f16 -> smallest, % + x-down) + the format size table
- Available files table (file | PPL | size | Mean KLD | notes), --results feeds real PPL/KLD else "—" with a "benchmarking pending" note
- Usage (llama-cli + ollama for gguf; mlx/vllm per lane) + Errata + the standard footer. New --builds-from / --title / --repo / --results flags.

install.sh: also clone + build ik_llama.cpp (the trellis engine) so a fresh install can build/run the 1-bit-class flagship (IQ*_KT), not just stock K-quants. Skippable with POLLARD_NO_IK=1. Root cause of "the Mac couldn't build the flagship": install.sh only built stock llama.cpp.

Verified live: PollardWeights/MiniCPM5-2B-Pollard (GGUF) and -Pollard-MLX now match the standard. Gates green.