### PR TITLE
fix(card): lane-aware cards + MLX rungs record distinctly

### DIFF
--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -115,17 +115,22 @@ def main():
     pct = (1 - small_gb / f16_gb) * 100 if f16_gb else 0
     x = f16_gb / small_gb if small_gb else 0
 
+    primary = a.lane or (lanes[0] if lanes else "gguf")
+    lane_word = {"gguf": "", "mlx": " for Apple Silicon", "gptq": " for vLLM/SGLang",
+                 "mx": " for Blackwell/vLLM", "exl3": " for exllamav3"}.get(primary, "")
     # ---- frontmatter + hero
     out = [frontmatter(base_model, lic, lanes, mtype), "", f"# {name} — Pollard", ""]
     if f16_gb and small_gb:
-        out += [f"> ### Pollard shrank this model: **{f16_gb:.1f} GB (f16) → {small_gb:.2f} GB** — "
+        out += [f"> ### Pollard shrank this model{lane_word}: **{f16_gb:.1f} GB (f16) → {small_gb:.2f} GB** — "
                 f"**{pct:.0f}% smaller, {x:.1f}× down**.",
-                f"> The smallest rung here; larger, higher-fidelity rungs are listed below.", ">",
-                "> | format | this model's size |", "> |---|---:|", f"> | f16 | {f16_gb:.1f} GB |"]
-        for fmt, mult in FMT_BPP.items():
-            if fmt in ("Q8_0", "Q6_K", "Q4_K_M"):
-                out.append(f"> | {fmt} | ~{pb*mult:.1f} GB |")
-        out += [f"> | **PollardMix (this repo's {smallest.get('tag','best')})** | **{small_gb:.2f} GB** |", ""]
+                "> The smallest rung here; larger, higher-fidelity rungs are listed below."]
+        if primary == "gguf":          # the format size table is GGUF-specific
+            out += [">", "> | format | this model's size |", "> |---|---:|", f"> | f16 | {f16_gb:.1f} GB |"]
+            for fmt, mult in FMT_BPP.items():
+                if fmt in ("Q8_0", "Q6_K", "Q4_K_M"):
+                    out.append(f"> | {fmt} | ~{pb*mult:.1f} GB |")
+            out.append(f"> | **PollardMix (this repo's {smallest.get('tag','best')})** | **{small_gb:.2f} GB** |")
+        out.append("")
     out += [f"Pollard builds of [{base_model}](https://huggingface.co/{base_model}) made with "
             "[Pollard Weights](https://github.com/WestWaters/pollard-weights) — a ladder of "
             "**measured-allocation** quants (bits placed by per-layer sensitivity, not a uniform crush).", ""]

--- a/tools/pollard_mlx.py
+++ b/tools/pollard_mlx.py
@@ -145,7 +145,9 @@ def main():
         convert(a.model, **ckw)
     try:
         import pollard_workspace as ws
-        ws.record_build(a.model, "mlx", a.out, tag=f"{LOW}.{HIGH}")
+        # record the ACTUAL avg bpw + a distinct tag so each ladder rung is listable on the card
+        # (was always "4.8" regardless of the mix, so rungs collided)
+        ws.record_build(a.model, "mlx", a.out, tag=f"mlx-{avg:.1f}bpw", bpw=round(avg, 2))
     except Exception as e:
         print(f"   (warning: could not record build to the workspace manifest: {e})")
     print(f"wrote MLX model -> {a.out}\n"


### PR DESCRIPTION
pollard-card was GGUF-shaped for every lane (GGUF size table, "runs in llama.cpp" on MLX cards, etc.). Now the body branches by primary lane: the format size table is GGUF-only, the hero says "for Apple Silicon / vLLM / exllamav3" per lane, and usage/errata already keyed per lane. So MLX/GPTQ/MX/EXL3 cards match the standard without GGUF-isms — cards match for ANY lane, not just GGUF.

pollard-mlx now records each build with a distinct tag + real avg bpw (mlx-<bpw>bpw) instead of the constant "4.8", so ladder rungs (q8/mix/q4) are individually listable on the card (they were colliding).

Verified: MiniCPM5-2B-Pollard (GGUF) and -Pollard-MLX (q8/mix/q4 ladder) both live and matching the standard. Gates green.