### PR TITLE
fix: trust_remote_code for smooth/abliterate + force UTF-8 + declare …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-convert = ["torch", "transformers", "safetensors"]                 # measure/precondition/verify/probe/sensitivity/gptq
+convert = ["torch", "transformers", "safetensors", "datasets"]     # measure/precondition/verify/probe/sensitivity/calib
+gptq = ["torch", "transformers", "safetensors", "gptqmodel", "datasets"]   # pollard-export (vLLM/SGLang GPTQ lane)
 charts = ["matplotlib"]                                             # pollard-eval --chart / experiments/plot_*.py
 exl3 = ["torch", "transformers", "safetensors", "exllamav3", "datasets"]
 mlx = ["mlx-lm"]
-mx = ["torch", "transformers", "llmcompressor"]
+mx = ["torch", "transformers", "llmcompressor", "datasets"]
 hf = ["huggingface-hub", "hf-transfer"]                            # publishing to the Hub
-all = ["torch", "transformers", "safetensors", "exllamav3", "datasets",
+all = ["torch", "transformers", "safetensors", "exllamav3", "datasets", "gptqmodel",
        "mlx-lm", "llmcompressor", "huggingface-hub", "hf-transfer", "matplotlib"]
 
 [project.scripts]

--- a/tools/pollard_abliterate.py
+++ b/tools/pollard_abliterate.py
@@ -114,6 +114,8 @@ def main():
     ap.add_argument("--out", help="output dir for the abliterated FP16 model")
     ap.add_argument("--layer", default="auto", help="direction layer index, or 'auto'")
     ap.add_argument("--device", default="mps")
+    ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
+                    help="run a model's own modeling code (custom archs); 'auto' = only if config has auto_map")
     ap.add_argument("--selftest", action="store_true",
                     help="mechanism canary on the benign smoke sets — writes nothing")
     a = ap.parse_args()
@@ -129,13 +131,16 @@ def main():
             sys.exit("ERROR: pass --out for the abliterated model.")
 
     from transformers import AutoModelForCausalLM, AutoTokenizer
+    import pollard_workspace as ws
+    trc = ws.resolve_trust_remote_code(a.model, a.trust_remote_code)
     dev = a.device if (a.device != "mps" or torch.backends.mps.is_available()) else "cpu"
     print(f"== pollard-abliterate :: {a.model}  dev={dev}", flush=True)
-    tok = AutoTokenizer.from_pretrained(a.model)
+    tok = AutoTokenizer.from_pretrained(a.model, trust_remote_code=trc)
     if tok.pad_token is None:
         tok.pad_token = tok.eos_token
     tok.padding_side = "left"
-    model = AutoModelForCausalLM.from_pretrained(a.model, dtype=torch.float16).to(dev).eval()
+    model = AutoModelForCausalLM.from_pretrained(a.model, dtype=torch.float16,
+                                                trust_remote_code=trc).to(dev).eval()
 
     A = _load_lines(a.harmful) if a.harmful else _SMOKE_A
     B = _load_lines(a.harmless) if a.harmless else _SMOKE_B

--- a/tools/pollard_auto.py
+++ b/tools/pollard_auto.py
@@ -120,9 +120,10 @@ def _precondition_hf(a, hf_dir):
     Returns the (possibly transformed) HF dir."""
     here = os.path.dirname(os.path.abspath(__file__))
     cur = hf_dir
+    trc = ["--trust-remote-code", getattr(a, "trust_remote_code", "auto")]   # custom-arch passthrough
     if getattr(a, "abliterate", False):
         out = cur.rstrip("/\\") + "-abliterated"
-        cmd = [sys.executable, os.path.join(here, "pollard_abliterate.py"), "--model", cur, "--out", out]
+        cmd = [sys.executable, os.path.join(here, "pollard_abliterate.py"), "--model", cur, "--out", out] + trc
         if a.harmful: cmd += ["--harmful", a.harmful]
         if a.harmless: cmd += ["--harmless", a.harmless]
         print(f"   [precondition] abliterate (uncensor, FP16, opt-in): {' '.join(cmd)}")
@@ -131,7 +132,7 @@ def _precondition_hf(a, hf_dir):
         cur = out
     if getattr(a, "smooth", False):
         out = cur.rstrip("/\\") + "-smoothed"
-        cmd = [sys.executable, os.path.join(here, "pollard_hf_smooth.py"), "--model", cur, "--out", out]
+        cmd = [sys.executable, os.path.join(here, "pollard_hf_smooth.py"), "--model", cur, "--out", out] + trc
         if a.calib: cmd += ["--calib", a.calib]
         print(f"   [precondition] smooth (SmoothQuant, FP16): {' '.join(cmd)}")
         if a.run and subprocess.run(cmd).returncode != 0:

--- a/tools/pollard_export.py
+++ b/tools/pollard_export.py
@@ -230,8 +230,9 @@ def main():
     try:
         from gptqmodel import GPTQModel, QuantizeConfig
     except Exception:
-        sys.exit("ERROR: gptqmodel not installed here. Run this on the CUDA box: "
-                 "pip install gptqmodel ; the checkpoint it writes loads in vLLM/SGLang.")
+        sys.exit("ERROR: gptqmodel not installed here. On the CUDA box: "
+                 "pip install 'pollard-weights[gptq]' (or pip install gptqmodel). "
+                 "The checkpoint it writes loads in vLLM/SGLang.")
     if not a.calib:
         sys.exit("ERROR: --calib is required to build (use --plan-only / --shard-plan for planning only).")
     calib = [ln.strip() for ln in open(a.calib, encoding="utf-8") if ln.strip()]

--- a/tools/pollard_hf_smooth.py
+++ b/tools/pollard_hf_smooth.py
@@ -48,12 +48,18 @@ def main():
     ap.add_argument("--rows", type=int, default=12, help="calibration chunks")
     ap.add_argument("--cols", type=int, default=512, help="calibration chunk length (tokens)")
     ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
+                    help="run a model's own modeling code (custom archs like Spark2_5); 'auto' = only if "
+                         "config.json has an auto_map")
     a = ap.parse_args()
 
     import torch
+    import pollard_workspace as ws
+    trc = ws.resolve_trust_remote_code(a.model, a.trust_remote_code)
     from transformers import AutoModelForCausalLM, AutoTokenizer
-    tok = AutoTokenizer.from_pretrained(a.model)
-    model = AutoModelForCausalLM.from_pretrained(a.model, dtype=torch.float16, device_map=a.device)
+    tok = AutoTokenizer.from_pretrained(a.model, trust_remote_code=trc)
+    model = AutoModelForCausalLM.from_pretrained(a.model, dtype=torch.float16, device_map=a.device,
+                                                trust_remote_code=trc)
     model.eval()
     try:
         layers = model.model.layers

--- a/tools/pollard_workspace.py
+++ b/tools/pollard_workspace.py
@@ -18,8 +18,18 @@ Tools call `resolve_out(model, lane, tag, explicit)` — if the user passed --ou
 the build lands in the workspace automatically. After a build, call `record_build(...)` to log it to the
 model's MANIFEST so `pollard-ls` can show what exists and whether it verified.
 """
-import json, os, time
+import json, os, sys, time
 from datetime import datetime, timezone
+
+# Windows consoles default to cp1252 and CRASH (UnicodeEncodeError) on the progress bars / emoji that
+# Pollard and its deps (gptqmodel, llm-compressor, tqdm) print. Every Pollard tool imports this module,
+# so forcing UTF-8 here — at import, before those deps load — makes the whole toolchain safe on Windows
+# with no PYTHONUTF8 env needed. errors="replace" so an odd byte degrades a glyph instead of crashing.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
 
 
 def pollard_home() -> str:


### PR DESCRIPTION
…gptqmodel/datasets deps

Three robustness fixes from the Spark2_5 (custom arch) box run:

- trust_remote_code on pollard-hf-smooth and pollard-abliterate (they load via AutoModel/AutoTokenizer and were the last preconditioners without it) + the pollard one-shot passes --trust-remote-code through to both. So the FULL gold recipe (smoothing/abliterate) now works on custom archs, not just the export lanes — no more --no-smooth workaround for Spark-class models.

- Force UTF-8 on stdout/stderr at pollard_workspace import (every tool imports it, before heavy deps load). Windows consoles default to cp1252 and CRASH on the progress bars / emoji that Pollard, gptqmodel, llm-compressor, and tqdm print. No more UnicodeEncodeError, no PYTHONUTF8 env needed. errors="replace".

- Declare the missing deps: new `gptq` extra (torch/transformers/safetensors/ gptqmodel/datasets) for the pollard-export lane — gptqmodel was in NO extra, so `pip install pollard-weights[all]` didn't get it (the box had to install it by hand). Added datasets to convert/mx (calib/probe use it) and gptqmodel to all. Export's error now points at pip install 'pollard-weights[gptq]'.

Gates green (py_compile, pyproject consistency, 14 tests); UTF-8 reconfigure verified.