### PR TITLE
Feat envmatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,11 @@ Thumbs.db
 *.mov
 *.webm
 *.wav
+
+# Pollard workspace / matched envs — created at $POLLARD_HOME (default ~/pollard), normally OUTSIDE the
+# repo; ignored here too in case someone points POLLARD_HOME inside a checkout, so a venv/weights never commit.
+envs/
+pollard/
+phome/
+pyvenv.cfg
+POLLARD_HOME/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,9 @@ pollard-palette = "pollard_palette:main"
 pollard-serve-eval = "pollard_serve_eval:main"
 pollard-card = "pollard_card:main"
 pollard-onboard = "pollard_onboard:main"
+pollard-envmatch = "pollard_envmatch:main"
 
 [tool.setuptools]
 package-dir = { "" = "tools" }
 py-modules = ["pollard_auto", "pollard_calc", "pollard_fit", "pollard_run", "pollard_fit_dit", "pollard_experts", "pollard_sensitivity", "pollard_smooth", "pollard_rotate", "pollard_precondition", "pollard_eval", "pollard_health", "pollard_pack", "pollard_prune", "pollard_bench", "pollard_export", "pollard_gptq", "pollard_automap", "pollard_abliterate", "pollard_probe", "pollard_probes", "pollard_scorecard", "pollard_kl", "pollard_lowbit", "pollard_verify", "pollard_doctor", "pollard_hf_smooth", "pollard_mx", "pollard_mlx", "pollard_exl3", "pollard_calib", "pollard_palette", "pollard_ls", "pollard_workspace",
-    "pollard_serve_eval", "pollard_card", "pollard_onboard", "imatrix_fix_gate"]
+    "pollard_serve_eval", "pollard_card", "pollard_onboard", "pollard_envmatch", "imatrix_fix_gate"]

--- a/tools/pollard_auto.py
+++ b/tools/pollard_auto.py
@@ -283,6 +283,10 @@ def main():
     ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
                     help="run a model's own modeling code for custom archs (Spark2_5 etc.); 'auto' enables "
                          "it only when config.json declares an auto_map. Passed through to the export lanes.")
+    ap.add_argument("--match-transformers", default="auto", choices=["auto", "on", "off"],
+                    help="build a custom-arch model in a cached env pinned to the transformers version it was "
+                         "SAVED with (config.json), so its remote code doesn't crash on a newer transformers. "
+                         "'auto' = only when the majors differ; 'off' = always use the current env.")
     ap.add_argument("--imatrix", help="importance matrix (auto-generated from Calib 3.0 if omitted)")
     ap.add_argument("--calib", help="calibration corpus for auto-imatrix (else Calib 3.0 auto-built)")
     ap.add_argument("--ngl", default="99", help="GPU layers for auto-imatrix (lower for a big model)")
@@ -331,6 +335,28 @@ def main():
     # NON-GGUF lanes (GPTQ/MLX) emit straight from HF weights — route and done.
     if a.format in ("gptq", "mlx", "exl3", "mx"):
         print(f"pollard :: {a.hf or a.gguf}  -> {a.format.upper()} lane")
+        # Auto-version onboarding: a custom-arch model saved with an older transformers major will crash
+        # its remote code under the current one. Build the whole lane in a cached env pinned to the model's
+        # transformers_version instead (Spark2_5 needs 4.57.1 vs a 5.x box). Re-invoke this same one-shot
+        # under that env (with --match-transformers off to avoid recursion) so smooth/probe/export all match.
+        if a.hf and a.match_transformers != "off":
+            try:
+                import pollard_envmatch as em
+                target = (em.needs_matched_env(a.hf) if a.match_transformers == "auto"
+                          else em.model_transformers_version(a.hf))
+                if target:
+                    print(f"   [match-transformers] {a.hf} was saved with transformers {target}; "
+                          f"building in a matched env (its remote code needs it)")
+                    if not a.run:
+                        print("   (plan) --run would provision the matched env and build the lane there.")
+                        return
+                    py = em.ensure_env(target, a.format)
+                    if py:
+                        argv = [py, os.path.abspath(__file__)] + sys.argv[1:] + ["--match-transformers", "off"]
+                        sys.exit(subprocess.run(argv).returncode)
+                    print("   [match-transformers] env setup failed — falling back to the current env")
+            except Exception as e:
+                print(f"   [match-transformers] skipped ({e}); using the current env")
         _emit_nongguf(a)
         if not a.run:
             print("\n   plan only — re-run with --run to execute.")

--- a/tools/pollard_envmatch.py
+++ b/tools/pollard_envmatch.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""pollard_envmatch — build a custom-architecture model in a Python env matched to the transformers
+version it was SAVED with, so its remote modeling code actually runs.
+
+A model whose config.json says `transformers_version: 4.57.1` and ships its own modeling code (auto_map)
+will crash under transformers 5.x — the internal APIs its code calls (e.g. `create_causal_mask`) drift
+between majors. Spark-X2.5-4B is the canonical case: `create_causal_mask() got an unexpected keyword
+argument 'input_embeds'` under transformers 5.15.
+
+This reads that version and provisions a CACHED venv at `$POLLARD_HOME/envs/tv-<ver>/` with the matched
+transformers + the lane's deps + Pollard (editable), so the export lanes build there instead of crashing.
+Stock archs (no auto_map) are left alone — they're forward-compatible and use the current env.
+
+Used by the `pollard` one-shot automatically (--match-transformers auto|on|off); also runnable:
+  pollard-envmatch --model XHToken/Spark-X2.5-4B --lane gptq   # print/ensure the matched env
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+# per-lane pip extras the matched env needs (transformers is pinned separately)
+LANE_DEPS = {
+    "gptq": ["torch", "safetensors", "gptqmodel", "datasets"],
+    "mx": ["torch", "safetensors", "llmcompressor", "datasets"],
+    "mlx": ["mlx-lm"],
+    "exl3": ["torch", "safetensors", "exllamav3", "datasets"],
+    "probe": ["torch", "safetensors", "datasets"],
+    "smooth": ["torch", "safetensors"],
+}
+
+
+def _read_config(model):
+    try:
+        if os.path.isdir(model):
+            return json.load(open(os.path.join(model, "config.json")))
+        from huggingface_hub import hf_hub_download
+        return json.load(open(hf_hub_download(model, "config.json")))
+    except Exception:
+        return {}
+
+
+def model_transformers_version(model):
+    return _read_config(model).get("transformers_version")
+
+
+def has_custom_code(model):
+    return bool(_read_config(model).get("auto_map"))
+
+
+def installed_transformers_version():
+    try:
+        import transformers
+        return transformers.__version__
+    except Exception:
+        return None
+
+
+def needs_matched_env(model):
+    """Return the target transformers version to match, or None if the current env is fine.
+    Only custom-code models (auto_map) can break on a version drift; stock archs stay on the
+    current transformers. Trigger on a MAJOR mismatch (4.x vs 5.x) — the API-breaking kind."""
+    if not has_custom_code(model):
+        return None
+    target = model_transformers_version(model)
+    cur = installed_transformers_version()
+    if not target or not cur:
+        return None
+    if target.split(".")[0] != cur.split(".")[0]:      # different major -> API drift risk
+        return target
+    return None
+
+
+def _env_python(envdir):
+    win = os.path.join(envdir, "Scripts", "python.exe")
+    nix = os.path.join(envdir, "bin", "python")
+    return win if os.path.exists(win) else nix
+
+
+def ensure_env(version, lane, pollard_repo=None):
+    """Create (or reuse) a cached venv pinned to transformers==version with the lane's deps + Pollard.
+    Returns the path to that env's python. Cached at $POLLARD_HOME/envs/tv-<version>/ and reused."""
+    home = os.path.abspath(os.environ.get("POLLARD_HOME", os.path.expanduser("~/pollard")))
+    envdir = os.path.join(home, "envs", f"tv-{version}")
+    py = _env_python(envdir)
+    marker = os.path.join(envdir, f".ready-{lane}")
+    if os.path.exists(py) and os.path.exists(marker):
+        return py
+    if not os.path.exists(py):
+        print(f"   [envmatch] creating matched env (transformers=={version}) at {envdir}")
+        subprocess.run([sys.executable, "-m", "venv", envdir], check=True)
+        py = _env_python(envdir)
+    repo = pollard_repo or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    deps = ["transformers==" + version] + LANE_DEPS.get(lane, ["torch", "safetensors"])
+    print(f"   [envmatch] installing transformers=={version} + {lane} deps + pollard (cached after first run)")
+    subprocess.run([py, "-m", "pip", "install", "-q", "--upgrade", "pip"], check=False)
+    r = subprocess.run([py, "-m", "pip", "install", "-q", *deps, "-e", repo])
+    if r.returncode != 0:
+        print("   [envmatch] pip install failed — the lane will run in the current env (may crash on the arch)")
+        return None
+    open(marker, "w").write(version)
+    return py
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0],
+                                 formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
+    ap.add_argument("--model", required=True, help="HF repo id or local dir")
+    ap.add_argument("--lane", default="gptq", choices=sorted(LANE_DEPS), help="lane whose deps to install")
+    ap.add_argument("--ensure", action="store_true", help="actually create/populate the env (else just report)")
+    a = ap.parse_args()
+
+    tv = model_transformers_version(a.model)
+    cur = installed_transformers_version()
+    custom = has_custom_code(a.model)
+    target = needs_matched_env(a.model)
+    print(f"== pollard-envmatch :: {a.model}")
+    print(f"   model transformers_version: {tv or 'unspecified'} | installed: {cur or 'none'} | custom code: {custom}")
+    if not target:
+        print("   verdict: current env is fine (stock arch or matching major) — no matched env needed.")
+        return
+    print(f"   verdict: MATCHED ENV needed — build the {a.lane} lane under transformers=={target}")
+    if a.ensure:
+        py = ensure_env(target, a.lane)
+        print(f"   env python: {py}" if py else "   env setup failed.")
+    else:
+        print(f"   (run with --ensure to provision it, or `pollard --hf {a.model} --format {a.lane} --run` "
+              "does it automatically)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
the .gitignore insurance (envs/, pollard/, phome/, pyvenv.cfg, POLLARD_HOME/) is now in the feat-envmatch