### PR TITLE
feat(alloc): --focus-layers to steer the budget to user-chosen layers

### DIFF
--- a/tools/pollard_auto.py
+++ b/tools/pollard_auto.py
@@ -213,6 +213,8 @@ def _emit_nongguf(a):
     here = os.path.dirname(os.path.abspath(out)) or "."
 
     trc = ["--trust-remote-code", a.trust_remote_code]     # custom-arch passthrough (Spark2_5 etc.)
+    if a.focus_layers:                                     # user-steered budget passthrough
+        trc += ["--focus-layers", a.focus_layers]
     if a.format == "gptq":
         calib = _ensure_calib_text(a, here)
         sens = _ensure_sensitivity(a, hf_dir, calib, here)
@@ -283,6 +285,8 @@ def main():
     ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
                     help="run a model's own modeling code for custom archs (Spark2_5 etc.); 'auto' enables "
                          "it only when config.json declares an auto_map. Passed through to the export lanes.")
+    ap.add_argument("--focus-layers", help="steer the budget: force these layer indices to HIGH bits on "
+                    "the export lanes (gptq/mlx/mx), e.g. '3,4,8' or '3-8,16'. Unions into the measured hot set.")
     ap.add_argument("--match-transformers", default="auto", choices=["auto", "on", "off"],
                     help="build a custom-arch model in a cached env pinned to the transformers version it was "
                          "SAVED with (config.json), so its remote code doesn't crash on a newer transformers. "

--- a/tools/pollard_export.py
+++ b/tools/pollard_export.py
@@ -58,19 +58,24 @@ def detect_mla(model_id):
         return False
 
 
-def allocate(sens, n_layers, hot_frac):
+parse_layers = ws.parse_layers   # shared layer-spec parser
+
+
+def allocate(sens, n_layers, hot_frac, focus=None):
     """Pollard profile -> {layer: {group: bits}}. The most-sensitive `hot_frac` of layers
     keep their group at 8-bit; the rest go 4-bit. Fused groups get ONE bit-width (constraint).
     'attn' sensitivity drives q/k/v+o; 'ffn' sensitivity drives gate/up+down."""
+    focus = set(focus or ())                       # user-chosen layers to force HIGH (steer the budget)
     ffn = {int(k): float(v) for k, v in (sens.get("ffn") or {}).items()}
     attn = {int(k): float(v) for k, v in (sens.get("attn") or {}).items()}
-    if not ffn and not attn:                       # no profile -> uniform W4 (still valid)
-        return {i: {"attn": LOW, "ffn": LOW} for i in range(n_layers)}
+    if not ffn and not attn:                       # no profile -> uniform W4, but honor --focus-layers
+        return {i: {"attn": HIGH if i in focus else LOW,
+                    "ffn": HIGH if i in focus else LOW} for i in range(n_layers)}
 
     def hot_layers(d):
         k = max(1, int(round(hot_frac * len(d))))
         return set(sorted(d, key=lambda i: d[i], reverse=True)[:k])
-    hot_attn, hot_ffn = hot_layers(attn or ffn), hot_layers(ffn or attn)
+    hot_attn, hot_ffn = hot_layers(attn or ffn) | focus, hot_layers(ffn or attn) | focus
     return {i: {"attn": HIGH if i in hot_attn else LOW,
                 "ffn": HIGH if i in hot_ffn else LOW} for i in range(n_layers)}
 
@@ -176,6 +181,9 @@ def main():
     ap.add_argument("--out", help="output dir for the GPTQ checkpoint (default: workspace)")
     ap.add_argument("--layers", type=int, default=0, help="n decoder layers (else read from config)")
     ap.add_argument("--hot-frac", type=float, default=0.35, help="fraction of layers kept at 8-bit")
+    ap.add_argument("--focus-layers", help="force these layer indices to HIGH bits regardless of the "
+                    "sensitivity profile — steer the budget to layers you care about, e.g. '3,4,8' or "
+                    "'3-8,16'. Unions into the measured hot set (works even with no profile).")
     ap.add_argument("--group-size", type=int, default=128)
     ap.add_argument("--uniform", action="store_true", help="plain uniform W4 (for SGLang mixed-bit fragility)")
     ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
@@ -205,7 +213,10 @@ def main():
         print_shard_plan(a.model, n_layers, a.shard_plan, a.bf16_gb)
         return
 
-    alloc = allocate(sens, n_layers, a.hot_frac)
+    focus = parse_layers(a.focus_layers)
+    if focus:
+        print(f"   focus-layers: forcing layers {sorted(focus)} to HIGH (steered budget)")
+    alloc = allocate(sens, n_layers, a.hot_frac, focus=focus)
     dyn = {} if a.uniform else (moe_dynamic_config(alloc) if is_moe else dynamic_config(alloc))
     ab = LOW if a.uniform else avg_bits(alloc)
     kind = "MoE" if is_moe else "dense"

--- a/tools/pollard_mlx.py
+++ b/tools/pollard_mlx.py
@@ -30,17 +30,20 @@ def detect_moe(model_id, layers_hint=0):
         return False, layers_hint
 
 
-def allocate(sens, n_layers, hot_frac):
-    """Pollard profile -> {layer: {"attn":bits, "ffn":bits}}. Top `hot_frac` of layers stay HIGH."""
+def allocate(sens, n_layers, hot_frac, focus=None):
+    """Pollard profile -> {layer: {"attn":bits, "ffn":bits}}. Top `hot_frac` of layers stay HIGH.
+    `focus` (layer indices) are forced HIGH regardless of the profile (steer the budget)."""
+    focus = set(focus or ())
     ffn = {int(k): float(v) for k, v in (sens.get("ffn") or {}).items()}
     attn = {int(k): float(v) for k, v in (sens.get("attn") or {}).items()}
     if not ffn and not attn:
-        return {i: {"attn": LOW, "ffn": LOW} for i in range(n_layers)}
+        return {i: {"attn": HIGH if i in focus else LOW,
+                    "ffn": HIGH if i in focus else LOW} for i in range(n_layers)}
 
     def hot(d):
         k = max(1, int(round(hot_frac * len(d))))
         return set(sorted(d, key=lambda i: d[i], reverse=True)[:k])
-    ha, hf = hot(attn or ffn), hot(ffn or attn)
+    ha, hf = hot(attn or ffn) | focus, hot(ffn or attn) | focus
     return {i: {"attn": HIGH if i in ha else LOW, "ffn": HIGH if i in hf else LOW}
             for i in range(n_layers)}
 
@@ -79,6 +82,8 @@ def main():
     ap.add_argument("--out", help="output MLX model dir (required unless --plan-only)")
     ap.add_argument("--layers", type=int, default=0)
     ap.add_argument("--hot-frac", type=float, default=0.35)
+    ap.add_argument("--focus-layers", help="force these layers to HIGH (8-bit) regardless of the profile, "
+                    "e.g. '3,4,8' or '3-8,16' — steer the budget to layers you care about")
     ap.add_argument("--group-size", type=int, default=64, help="MLX quant group size (default 64)")
     ap.add_argument("--trust-remote-code", default="auto", choices=["auto", "on", "off"],
                     help="run a model's own modeling code (custom archs); 'auto' = only if config has auto_map. "
@@ -96,7 +101,11 @@ def main():
     if not n_layers:
         sys.exit("ERROR: could not read layer count — pass --layers.")
     is_moe = auto_moe if a.moe is None else a.moe
-    alloc = allocate(sens, n_layers, a.hot_frac)
+    import pollard_workspace as ws
+    focus = ws.parse_layers(a.focus_layers)
+    if focus:
+        print(f"   focus-layers: forcing layers {sorted(focus)} to 8-bit (steered budget)")
+    alloc = allocate(sens, n_layers, a.hot_frac, focus=focus)
     avg = sum(g["attn"] + g["ffn"] for g in alloc.values()) / (2 * len(alloc))
     kind = "MoE" if is_moe else "dense"
     print(f"== pollard-mlx :: {a.model}  [{kind}]  {n_layers} layers · mix {LOW}/{HIGH}-bit "

--- a/tools/pollard_mx.py
+++ b/tools/pollard_mx.py
@@ -28,9 +28,10 @@ import argparse, json, os, sys
 import pollard_workspace as ws
 
 
-def allocate(sens, n_layers, hot_frac):
+def allocate(sens, n_layers, hot_frac, focus=None):
     """Rank layers by measured sensitivity; the hottest `hot_frac` stay FP8, the rest go FP4.
-    Mirrors pollard-export's hot/cold split so the FP4 lane inherits the same measured allocation."""
+    Mirrors pollard-export's hot/cold split so the FP4 lane inherits the same measured allocation.
+    `focus` (layer indices) are forced HIGH regardless of the profile (steer the budget)."""
     if sens:
         order = sorted(sens.items(), key=lambda kv: -float(kv[1]))
         hot = set(k for k, _ in order[:max(1, int(round(hot_frac * len(order))))])
@@ -38,6 +39,7 @@ def allocate(sens, n_layers, hot_frac):
         # no profile -> protect the ends (embeddings-adjacent + final layers empirically most sensitive)
         n_hot = max(1, int(round(hot_frac * n_layers)))
         hot = set(str(i) for i in list(range(n_hot // 2)) + list(range(n_layers - (n_hot - n_hot // 2), n_layers)))
+    hot |= {str(i) for i in (focus or ())}         # user-steered layers, always HIGH
     return hot
 
 
@@ -85,6 +87,8 @@ def main():
     ap.add_argument("--protect-scheme", default="FP8", choices=["FP8", "FP8_DYNAMIC", "W8A16"],
                     help="precision for the protected (hot) layers")
     ap.add_argument("--hot-frac", type=float, default=0.25, help="fraction of layers kept at FP8 (not FP4)")
+    ap.add_argument("--focus-layers", help="force these layers to HIGH (FP8) regardless of the profile, "
+                    "e.g. '3,4,8' or '3-8,16' — steer the budget to layers you care about")
     ap.add_argument("--protect-down", action="store_true",
                     help="also keep every down_proj (residual writer) at FP8 — usually worth it at 4-bit")
     ap.add_argument("--layers", type=int, default=0, help="n decoder layers (else read from config)")
@@ -106,7 +110,10 @@ def main():
         sens = json.load(open(a.sensitivity))
         sens = sens.get("layers", sens) if isinstance(sens, dict) else {}
 
-    hot = allocate(sens, n_layers or 32, a.hot_frac)
+    focus = ws.parse_layers(a.focus_layers)
+    if focus:
+        print(f"   focus-layers: forcing layers {sorted(focus)} to FP8 (steered budget)")
+    hot = allocate(sens, n_layers or 32, a.hot_frac, focus=focus)
     rec = build_recipe(hot, a.scheme, a.protect_scheme, a.protect_down)
     ab = avg_bits(n_layers or 32, a.hot_frac, a.protect_down, a.scheme, a.protect_scheme)
     is_int = a.scheme in ("W4A16", "W8A16")

--- a/tools/pollard_workspace.py
+++ b/tools/pollard_workspace.py
@@ -213,3 +213,18 @@ def resolve_trust_remote_code(model_id, mode="auto") -> bool:
         return False
     except Exception:
         return False
+
+
+def parse_layers(spec) -> set:
+    """Parse a layer spec like '3,4,8' or '3-8,16,20-22' into a set of ints. Empty -> empty set.
+    Shared by the allocation lanes for --focus-layers (steer the budget to chosen layers)."""
+    out = set()
+    for part in str(spec or "").replace(" ", "").split(","):
+        if not part:
+            continue
+        if "-" in part:
+            a, b = part.split("-", 1)
+            out.update(range(int(a), int(b) + 1))
+        else:
+            out.add(int(part))
+    return out


### PR DESCRIPTION
Per bitk0rns' call + the GLM-5.3 routing data (PR #36): routing is near-uniform except a few hot layers, so let users force specific layers to HIGH bits rather than only trusting hot-frac/sensitivity.

- --focus-layers "3,4,8" or "3-8,16" on pollard-export / -mx / -mlx and the `pollard` one-shot (passed through). Unions the chosen layers into the measured hot set; works even with no sensitivity profile (uniform + your focus).
- Shared ws.parse_layers (ranges + lists); export/mx/mlx allocate() take focus=.

Tested: parse ranges/lists; export/mlx/mx all force {3,4,8} HIGH with no profile. Gates green (py_compile, pyproject consistency, 14 tests).