### PR TITLE
workspace: add downloads/ staging home for pulled source models

### DIFF
--- a/tools/pollard_auto.py
+++ b/tools/pollard_auto.py
@@ -147,11 +147,11 @@ def _resolve_hf(a):
     if os.path.isdir(a.hf):
         a._hf_dir = _precondition_hf(a, a.hf)
         return a._hf_dir
-    local = os.path.join(os.path.abspath(a.output or "."), a.hf.split("/")[-1])
-    print(f"   fetch HF repo: huggingface-cli download {a.hf} --local-dir {local}")
+    import pollard_workspace as ws
+    local = ws.source_dir(a.hf)                         # $POLLARD_HOME/downloads/<slug> — one findable place
+    print(f"   fetch HF repo -> {local}  (workspace downloads/)")
     if a.run:
-        from huggingface_hub import snapshot_download
-        local = snapshot_download(a.hf, local_dir=local)
+        local = ws.fetch_source(a.hf)                   # single copy, no ~/.cache dup
     a._hf_dir = _precondition_hf(a, local)
     return a._hf_dir
 

--- a/tools/pollard_ls.py
+++ b/tools/pollard_ls.py
@@ -2,9 +2,10 @@
 """pollard-ls — list what's in the Pollard workspace so you never hunt for a build. Reads each model's
 MANIFEST.json and prints every build: lane, quant, size, PPL, and whether it passed pollard-verify.
 
-  pollard-ls                 # everything in $POLLARD_HOME (default ~/pollard)
-  pollard-ls Qwen2.5-3B      # just builds whose model matches this substring
+  pollard-ls                 # everything in $POLLARD_HOME (default ~/pollard): builds + pulled sources
+  pollard-ls Qwen2.5-3B      # just entries whose model matches this substring
   pollard-ls --paths         # print full paths (for scripting)
+  pollard-ls --clean-downloads   # delete downloads/ (source models are re-fetchable) to reclaim disk
 """
 import argparse, os
 import pollard_workspace as ws
@@ -15,7 +16,14 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
     ap.add_argument("filter", nargs="?", default="", help="only models matching this substring")
     ap.add_argument("--paths", action="store_true", help="print full build paths")
+    ap.add_argument("--clean-downloads", action="store_true",
+                    help="delete the downloads/ staging tree (pulled source models are re-fetchable)")
     a = ap.parse_args()
+
+    if a.clean_downloads:
+        freed = ws.clean_downloads()
+        print(f"cleared downloads/ — freed {ws.human(freed)}")
+        return
 
     home = ws.pollard_home()
     print(f"Pollard workspace: {home}")
@@ -42,6 +50,23 @@ def main():
             if a.paths:
                 print(f"       {b.get('path','')}")
     print(f"\ntotal: {ws.human(total)} across {len(models)} model(s)")
+
+    # pulled SOURCE models (the input side) — show them so they're findable and easy to reclaim
+    dl = ws.downloads_dir()
+    if os.path.isdir(dl):
+        srcs = sorted(d for d in os.listdir(dl) if os.path.isdir(os.path.join(dl, d)) and not d.startswith("."))
+        if srcs:
+            dtotal = 0
+            print(f"\ndownloads/ (pulled sources):")
+            for s in srcs:
+                if a.filter.lower() not in s.lower():
+                    continue
+                sz = ws._dir_size(os.path.join(dl, s)); dtotal += sz
+                print(f"   {s:<44} {ws.human(sz)}")
+                if a.paths:
+                    print(f"       {os.path.join(dl, s)}")
+            if dtotal:
+                print(f"   (source total: {ws.human(dtotal)} — reclaim with `pollard-ls --clean-downloads`)")
 
 
 if __name__ == "__main__":

--- a/tools/pollard_workspace.py
+++ b/tools/pollard_workspace.py
@@ -6,13 +6,16 @@ they ran the command.
 Layout (default ~/pollard, override with $POLLARD_HOME):
 
   ~/pollard/
-    models/
+    downloads/                                pulled SOURCE models (the input side), one findable copy
+      <Org>__<Model>/                         e.g. Qwen__Qwen2.5-3B (mirrors the models/ naming)
+      .hf-cache/                              hub cache pinned here so a pull can't dup into ~/.cache
+    models/                                   BUILT Pollard outputs (the output side)
       <Org>__<Model>/                         e.g. Qwen__Qwen2.5-3B
         <Model>-Pollard-<LANE>-<tag>/         runtime-ready build, HF-card-style name
         calibration/                          imatrix, cal data, sensitivity.json
         reports/                              pollard-verify / scorecard / ppl outputs
         MANIFEST.json                         every build here: lane, bpw, ppl, verified, size, date
-    cache/                                    downloads + _work dirs (safe to delete)
+    cache/                                    _work dirs (safe to delete)
 
 Tools call `resolve_out(model, lane, tag, explicit)` — if the user passed --out it's respected; otherwise
 the build lands in the workspace automatically. After a build, call `record_build(...)` to log it to the
@@ -72,6 +75,56 @@ def cache_dir(create: bool = False) -> str:
     d = os.path.join(pollard_home(), "cache")
     if create: os.makedirs(d, exist_ok=True)
     return d
+
+
+def downloads_dir(create: bool = False) -> str:
+    """Staging home for pulled SOURCE models — the input side, distinct from models/ (built outputs) and
+    cache/ (scratch). $POLLARD_HOME/downloads/<Org>__<Model>/ keeps every fetched model in one findable,
+    human-named place instead of scattered under wherever the command was run."""
+    d = os.path.join(pollard_home(), "downloads")
+    if create: os.makedirs(d, exist_ok=True)
+    return d
+
+
+def source_dir(model: str, create: bool = False) -> str:
+    """Per-source-model folder under downloads/, named like the models/ tree so the pair lines up."""
+    d = os.path.join(downloads_dir(), model_slug(model))
+    if create: os.makedirs(d, exist_ok=True)
+    return d
+
+
+def fetch_source(repo_id: str, filename: str | None = None, revision: str | None = None,
+                 allow_patterns=None, token: str | None = None) -> str:
+    """Pull an HF source model (or one file) into $POLLARD_HOME/downloads/<slug> — ONE findable copy.
+
+    Returns the local file path (when `filename` is given) or the model dir. A path that already exists
+    locally is returned as-is (point Pollard at a repo id OR a dir). The Xet backend is disabled (its
+    write token can expire mid-transfer, which stalls big pulls) and the hub cache is pinned INSIDE
+    downloads/ (`.hf-cache`) so a download can't silently duplicate the model into ~/.cache and fill the
+    disk — everything the pull touches lives under one folder you can see and clean. Idempotent: a
+    complete prior download is reused, not re-fetched."""
+    if os.path.exists(repo_id):                       # already a local dir/file — use it directly
+        return repo_id
+    os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
+    dest = source_dir(repo_id, create=True)
+    hf_cache = os.path.join(downloads_dir(), ".hf-cache")
+    if filename:
+        from huggingface_hub import hf_hub_download
+        return hf_hub_download(repo_id, filename, revision=revision, local_dir=dest,
+                               cache_dir=hf_cache, token=token)
+    from huggingface_hub import snapshot_download
+    return snapshot_download(repo_id, revision=revision, local_dir=dest, cache_dir=hf_cache,
+                             allow_patterns=allow_patterns, token=token)
+
+
+def clean_downloads() -> int:
+    """Delete the downloads/ staging tree (source models are re-pullable). Returns bytes freed."""
+    import shutil
+    d = downloads_dir()
+    n = _dir_size(d)
+    if os.path.isdir(d):
+        shutil.rmtree(d, ignore_errors=True)
+    return n
 
 
 def charts_dir(model: str | None = None, create: bool = False) -> str:


### PR DESCRIPTION
Pollard had an output home (models/) but no dedicated place for the SOURCE models it pulls, so they landed under wherever the command ran — and a snapshot_download could also duplicate the model into ~/.cache and fill the disk (the cause of our mid-build ENOSPC crashes).

- ws.downloads_dir()/source_dir()/fetch_source(): one findable copy under $POLLARD_HOME/downloads/<slug>; hub cache pinned inside downloads/ so a pull can't dup into ~/.cache; Xet disabled (token can expire mid-transfer); local-path passthrough; idempotent.
- pollard_auto: pull HF repos through fetch_source instead of output/cwd.
- pollard-ls: lists pulled sources + --clean-downloads to reclaim disk.
- ws.clean_downloads() helper; module docstring/layout updated.