### PR TITLE
benchmarks: the Unsloth Dynamic 3.0 head-to-head, set up to be fair

### DIFF
--- a/benchmarks/run_unsloth_h2h.sh
+++ b/benchmarks/run_unsloth_h2h.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Pollard vs Unsloth Dynamic 3.0 on Qwen3.8-27B, size-matched.
+# Protocol and the reasoning behind every choice: unsloth-qwen38-27b-headtohead.md
+#
+#   BIN=/path/to/llama.cpp/build/bin EVAL=/path/to/wiki.test.raw ./run_unsloth_h2h.sh
+#
+# This is a GPU job and it is long. Run it when the GPU is free (60/40 rule), not alongside a game.
+set -euo pipefail
+
+BIN=${BIN:?set BIN to the llama.cpp bin dir}
+EVAL=${EVAL:?set EVAL to the wikitext-2 raw test file}
+WORK=${WORK:-$PWD/h2h}
+NGL=${NGL:-99}
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+POLLARD_REPO=PollardWeights/Qwen3.8-27B-Pollard
+UNSLOTH_REPO=unsloth/Qwen3.8-27B-GGUF
+
+# The headline pair: 12.08 vs 12.04 GB, 0.3% apart. Size is the variable that must be controlled --
+# a 10% larger quant should win, and calling that a method win is how this comparison gets faked.
+POLLARD_F=Qwen3.8-27B-Pollard-IQ3_S.gguf
+UNSLOTH_F=Qwen3.8-27B-UD-IQ3_S.gguf
+# Near-lossless KL host. NOT BF16: that is 54.7 GB over two shards and will not fit beside both
+# candidates on a ~75 GB volume. KLD vs a Q8_0 host is what the 14B/30B cards already use -- but it
+# measures agreement-with-Q8_0, so say that when reporting.
+REF_F=Qwen3.8-27B-Q8_0.gguf
+
+mkdir -p "$WORK"
+export HF_HUB_DISABLE_XET=1 HF_HUB_DISABLE_PROGRESS_BARS=1
+
+fetch () {
+  python3 - "$1" "$2" "$WORK" <<'PY'
+import sys
+from huggingface_hub import hf_hub_download
+print(hf_hub_download(sys.argv[1], sys.argv[2], local_dir=sys.argv[3]))
+PY
+}
+
+echo "== fetching (about 53 GB)"
+P=$(fetch "$POLLARD_REPO" "$POLLARD_F" | tail -1)
+U=$(fetch "$UNSLOTH_REPO" "$UNSLOTH_F" | tail -1)
+R=$(fetch "$UNSLOTH_REPO" "$REF_F"     | tail -1)
+
+sz () { stat -f%z "$1" 2>/dev/null || stat -c%s "$1"; }
+PB=$(sz "$P"); UB=$(sz "$U")
+echo "== sizes"
+printf '   pollard %s bytes\n   unsloth %s bytes\n' "$PB" "$UB"
+python3 -c "p=$PB;u=$UB;print(f'   size gap: {(p-u)/u*100:+.2f}%  (a win under +2% is not a clean win)')"
+
+# pollard-bench was built for exactly this: one harness, matched size, PPL + mean/median KLD + top-1,
+# and a Pareto verdict across both files. Using it instead of hand-rolling keeps our number and the
+# rival's number on identical code paths, which is the whole point of a head-to-head.
+echo "== head-to-head board"
+python3 "$HERE/../tools/pollard_bench.py" \
+    --gguf "$P" --vs "$U" --ref "$R" \
+    --eval "$EVAL" --ngl "$NGL" \
+    --llama-perplexity "$BIN/llama-perplexity" --llama-cli "$BIN/llama-cli" \
+    --out "$WORK/results.json"
+
+echo "== coherence gate on both (a looping build is not competitive at any perplexity)"
+for f in "$P" "$U"; do
+  echo "--- $(basename "$f")"
+  python3 "$HERE/../tools/pollard_bench.py" --gguf "$f" --coherence --quick --ngl "$NGL" \
+      --llama-cli "$BIN/llama-cli" --llama-perplexity "$BIN/llama-perplexity" || true
+done
+
+echo
+echo "== done -> $WORK/results.json (feeds pollard-scorecard)"
+echo "   Report the size gap beside every number, and publish the losses too."

--- a/benchmarks/unsloth-qwen38-27b-headtohead.md
+++ b/benchmarks/unsloth-qwen38-27b-headtohead.md
@@ -1,0 +1,62 @@
+# Head-to-head: Pollard vs Unsloth Dynamic 3.0 — Qwen3.8-27B
+
+Unsloth's `Qwen3.8-27B-GGUF` is the most-liked GGUF on Hugging Face: 10.7M downloads and 3.7K likes
+in 24 days. It is the right thing to measure against, because it is what people actually run, and
+because "Dynamic 3.0" is a mixed-allocation method too — the honest question is not whether mixed
+beats uniform, it is whose allocation is better **at the same size**.
+
+## Why this comparison can be fair
+
+Both repos publish the same base model, and two rungs land within a few percent of each other. Size
+is the variable that has to be controlled: a quant that is 10% larger should win, and reporting that
+as a method win is the standard way this comparison gets faked.
+
+| pair | Pollard | Unsloth | size gap |
+|---|---|---|---|
+| **headline** | `Qwen3.8-27B-Pollard-IQ3_S` 12.08 GB | `Qwen3.8-27B-UD-IQ3_S` 12.04 GB | **+0.3%** |
+| secondary | `Qwen3.8-27B-Pollard-Q6_K` 22.43 GB | `Qwen3.8-27B-UD-Q6_K` 21.98 GB | +2.0% |
+| loose | `Qwen3.8-27B-Pollard-IQ4_XS` 15.72 GB | `Qwen3.8-27B-UD-Q4_K_S` 15.36 GB | +2.3% |
+
+The **IQ3_S pair is the experiment**: 0.3% apart in bytes, same base model, same file format, same
+runtime. Whatever separates them is allocation. Report the others as secondary, and state their size
+gap next to every number, because at 2% they are suggestive rather than decisive.
+
+## Protocol
+
+Everything below is held identical across both sides. Any difference here invalidates the result.
+
+- **Runtime**: one `llama.cpp` build, one binary, run back to back on one machine.
+- **Eval**: `wikitext-2` raw test, ctx 512, all chunks. The same file for both.
+- **Reference for KL**: Unsloth's `Q8_0` (29.05 GB) as the near-lossless host, not BF16 — the BF16
+  is 54.7 GB across two shards and the box has ~75 GB free, which does not leave room for BF16 plus
+  both candidates. `pollard-bench --ref` documents Q8_0/Q6_K as an accepted host. Say so in the
+  result; a Q8_0 reference measures agreement-with-Q8_0, not agreement-with-BF16.
+- **Metrics**, in the order they matter:
+  1. **Mean KL vs the reference** and **top-1 agreement** (`pollard-kl`) — the metric that survives.
+     PPL can tie while behaviour diverges.
+  2. **PPL** — the number everyone quotes, kept for comparability.
+  3. **tok/s**, single stream, same `-ngl`, same prompt.
+- **Sampling** for any generation: fixed seed, temp 0.7, top-p 0.9, repeat-penalty 1.15, ChatML.
+- **Coherence**: `pollard-bench --coherence` on both. A build that loops is not competitive at any
+  perplexity.
+
+## Reporting rules
+
+- Publish the losses too. If Unsloth wins a rung, that is the result, and it tells us where the
+  allocator needs work.
+- Every number carries its size gap. A win under +2% size is not a clean win.
+- Single machine, single run — state it. Invite replication.
+- ⚠️ Do NOT quote Unsloth's own published quality claims as the comparison. Measure their artifact
+  on our bench, or it is not a head-to-head.
+
+## Cost
+
+The two IQ3_S files are ~24 GB of download plus the ~29 GB reference. Three full-wikitext perplexity
+passes and one KL pass over a 27B on a 16 GB-VRAM box means partial offload; budget hours, not
+minutes, and run it when the GPU is free (see the 60/40 rule — this is a GPU job).
+
+## Status
+
+Not yet run. `benchmarks/run_unsloth_h2h.sh` executes it end to end and writes `results.json` in the
+shape `pollard-scorecard` consumes. The Pollard 27B card currently ships placeholder rows
+("(see repo)", "—") for PPL and tok/s; this is what fills them.


### PR DESCRIPTION
Unsloth's Qwen3.8-27B GGUF is the most-liked GGUF on Hugging Face -- 10.7M downloads, 3.7K likes in 24 days -- so it is the right thing to measure against. Dynamic 3.0 is a mixed-allocation method too, which makes the honest question not "does mixed beat uniform" but "whose allocation is better at the same size".

Size is the variable that has to be controlled, because a quant 10% larger should win and reporting that as a method win is how this comparison gets faked. Both repos publish rungs that nearly match:

  Pollard IQ3_S  12.08 GB  vs  Unsloth UD-IQ3_S  12.04 GB   -- +0.3%
  Pollard Q6_K   22.43 GB  vs  Unsloth UD-Q6_K   21.98 GB   -- +2.0%
  Pollard IQ4_XS 15.72 GB  vs  Unsloth UD-Q4_K_S 15.36 GB   -- +2.3%

The IQ3_S pair IS the experiment: 0.3% apart, same base model, same format, same runtime, so whatever separates them is allocation. The others are secondary and must carry their size gap next to every number.

run_unsloth_h2h.sh drives it through `pollard-bench --gguf ... --vs ... --ref`, which already exists for this and keeps our number and the rival's on identical code paths. KL host is Unsloth's Q8_0, not BF16: BF16 is 54.7 GB over two shards and does not fit beside both candidates on a ~75 GB volume. That measures agreement-with-Q8_0 and the note says so rather than implying BF16.

Reporting rules are in the note and they bind us: publish the losses, quote no number without its size gap, and never cite Unsloth's own published claims in place of measuring their artifact on our bench.

Not yet run -- it is a GPU job and the box is busy. The Pollard 27B card currently ships "(see repo)" and "--" for PPL and tok/s; this is what fills them.