### PR TITLE
K2-Horizon on Windows: ship the missing pre-tokenizer splitter (MSVC …

### DIFF
--- a/notes/custom-arch-onboarding.md
+++ b/notes/custom-arch-onboarding.md
@@ -57,6 +57,19 @@ The arch-agnostic work pays off here — these needed **no** Spark-specific hack
 | **MLX** | ⚠️ code-ready, but MLX conversion needs the arch supported inside `mlx_lm` — a truly custom block may not convert until mlx_lm (or a community port) adds it. Try it; if `convert` errors on the arch, that's an mlx_lm gap, not ours. |
 | **EXL3** | ❌ exllamav3 doesn't know `spark2_5` yet — skip until upstream adds it (don't force a recipe). |
 
+## Platform gotcha: a custom pre-tokenizer can break one OS only
+
+A new architecture usually ships a new pre-tokenizer regex, and llama.cpp only hand-codes a splitter for
+regexes it recognizes — anything else falls through to `std::regex`, whose Unicode-property support is
+**platform-dependent**. K2-Horizon hit exactly this: its `\p{L}`/`\p{M}` regex loads fine on macOS
+(libc++) and fails with `regex_error(error_escape)` on Windows (MSVC), so the same GGUF built on one
+machine could not be quantized *or* evaluated on the other. Full write-up and a ready patch:
+[`k2-horizon-msvc-regex.md`](k2-horizon-msvc-regex.md) · [`k2-horizon-msvc-regex.patch`](k2-horizon-msvc-regex.patch).
+
+When onboarding an arch, load a tiny GGUF of it on **every** OS you build on before trusting the toolchain
+— and keep a known-good model of a *different* arch as the control, so you can tell "this tokenizer is
+unsupported here" apart from "this build is broken."
+
 ## Verify, always
 Custom code + custom attention means the reconstruction check matters more, not less: gate every build
 with `pollard-verify` (decode-vs-source + end-to-end forward) and, on the served side, `pollard-serve-eval`.

--- a/notes/k2-horizon-msvc-regex.md
+++ b/notes/k2-horizon-msvc-regex.md
@@ -1,0 +1,64 @@
+# K2-Horizon GGUFs won't load on Windows/MSVC — and the fix
+
+**Symptom.** On a Windows build of [`MBZUAI-IFM/llama.cpp`](https://github.com/MBZUAI-IFM/llama.cpp)
+(the fork carrying the `k2-horizon` architecture), loading *any* K2-Horizon GGUF fails before a single
+token is produced:
+
+```
+Failed to process regex: '(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\r\n\p{L}\p{N}]?(?:\p{L}|\p{M}|‌|‍)+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+'
+Regex error: regex_error(error_escape): The expression contained an invalid escaped character
+```
+
+`llama-quantize`, `llama-imatrix` and `llama-perplexity` all fail the same way, so on Windows the fork
+can neither **build** nor **evaluate** a K2 model. The identical GGUF works on macOS.
+
+**Cause.** `LLAMA_VOCAB_PRE_TYPE_K2_HORIZON` in `src/llama-vocab.cpp` declares a pre-tokenizer regex
+using the Unicode property escapes `\p{L}`, `\p{M}` and the explicit `‌` / `‍` (ZWNJ/ZWJ).
+`unicode_regex_split_custom` in `src/unicode.cpp` has hand-written splitters for the GPT-2, Llama-3,
+Qwen2, Qwen3.5, Kimi-K2, AFMoE and other pre-tokenizers, but **no arm matched the K2-Horizon literal**,
+so it fell through to the general-purpose `std::regex` / `std::wregex` fallback. That fallback is
+platform-dependent: Apple's libc++ tolerates `\p{...}`, **MSVC's `std::regex` rejects it outright**.
+Hence the macOS/Windows split — it is a portability bug, not a bad GGUF.
+
+**Fix.** `k2-horizon-msvc-regex.patch` in this directory adds the missing custom splitter, so the
+`std::regex` fallback is never reached for this tokenizer. It clones the existing Llama-3 splitter and
+widens only the letter-run rule, because the K2 regex differs from Llama-3's in exactly one place —
+`\p{L}+` becomes `(?:\p{L}|\p{M}|‌|‍)+`:
+
+```cpp
+auto _is_k2_letter = [&] (const size_t pos) -> bool {
+    const uint32_t c = _get_cpt(pos);
+    if (c == 0x200C || c == 0x200D) {   // ZWNJ / ZWJ join into the letter run
+        return true;
+    }
+    const auto f = _get_flags(pos);
+    return f.is_letter || f.is_accent_mark;   // \p{L} | \p{M}
+};
+```
+
+Everything else — the contraction rule, `\p{N}{1,3}`, the punctuation run, the whitespace tail — is
+byte-for-byte the Llama-3 logic, which already matches K2's remaining alternatives.
+
+Apply it against the fork, then rebuild only the three tools you need:
+
+```bash
+git -C llama.cpp apply /path/to/k2-horizon-msvc-regex.patch
+cmake --build build --config Release -j 8 \
+      --target llama-quantize llama-imatrix llama-perplexity
+```
+
+**One caveat when regenerating this patch by hand:** the dispatch arm compares the regex by string
+*equality*, so the literal must match `llama-vocab.cpp` character for character. Read it out of that
+file programmatically rather than retyping it — a single wrong backslash silently reverts you to the
+broken fallback.
+
+**Verification** (RTX 5090, MSVC 2022, CUDA 12.8 — full wikitext-2, ctx 512):
+
+| check | before | after |
+|---|---|---|
+| K2-Horizon-3.7B f16 load | `error_escape` | loads |
+| K2-Horizon-3.7B f16 PPL | — | **11.2798** ± 0.0808 |
+| Qwen2.5-0.5B-Instruct Q8_0 control PPL | 13.6097 | **13.6097** |
+
+The Qwen control is the point of the second row: the patch fixes K2 without disturbing any existing
+splitter. This is worth upstreaming to the fork — it affects every Windows user of it.

--- a/notes/k2-horizon-msvc-regex.patch
+++ b/notes/k2-horizon-msvc-regex.patch
@@ -1,0 +1,172 @@
+diff --git a/src/unicode.cpp b/src/unicode.cpp
+index 93996f9..a584585 100644
+--- a/src/unicode.cpp
++++ b/src/unicode.cpp
+@@ -470,6 +470,156 @@ static std::vector<size_t> unicode_regex_split_custom_llama3(const std::string &
+     return bpe_offsets;
+ }
+ 
++static std::vector<size_t> unicode_regex_split_custom_k2_horizon(const std::string & text, const std::vector<size_t> & offsets) {
++    std::vector<size_t> bpe_offsets; // store the offset of each word
++    bpe_offsets.reserve(offsets.size()); // Reserve memory for the approximate size
++
++    const auto cpts = unicode_cpts_from_utf8(text);
++
++    size_t start = 0;
++    for (auto offset : offsets) {
++        const size_t offset_ini = start;
++        const size_t offset_end = start + offset;
++        assert(offset_end <= cpts.size());
++        start = offset_end;
++
++        static const uint32_t OUT_OF_RANGE = 0xFFFFFFFF;
++        auto _get_cpt = [&] (const size_t pos) -> uint32_t {
++            return (offset_ini <= pos && pos < offset_end) ? cpts[pos] : OUT_OF_RANGE;
++        };
++
++        auto _get_flags = [&] (const size_t pos) -> unicode_cpt_flags {
++            return (offset_ini <= pos && pos < offset_end) ? unicode_cpt_flags_from_cpt(cpts[pos]) : unicode_cpt_flags{};
++        };
++
++        // K2-Horizon: letter runs are (?:\p{L}|\p{M}|\u200C|\u200D)+
++        auto _is_k2_letter = [&] (const size_t pos) -> bool {
++            const uint32_t c = _get_cpt(pos);
++            if (c == 0x200C || c == 0x200D) {
++                return true;
++            }
++            const auto f = _get_flags(pos);
++            return f.is_letter || f.is_accent_mark;
++        };
++
++        size_t _prev_end = offset_ini;
++        auto _add_token = [&] (const size_t end) -> size_t {
++            assert(_prev_end <= end && end <= offset_end);
++            size_t len = end - _prev_end;
++            if (len > 0) {
++                bpe_offsets.push_back(len);
++            }
++            _prev_end = end;
++            //if (len > 0) {
++            //    std::string s = "";
++            //    for(size_t p = end-len; p < end; p++)
++            //        s += unicode_cpt_to_utf8(cpts[p]);
++            //    printf(">>> '%s'\n", s.c_str());
++            //}
++            return len;
++        };
++
++        for (size_t pos = offset_ini; pos < offset_end; /*pos++*/ ) {
++            const uint32_t cpt = _get_cpt(pos);
++            const auto flags = _get_flags(pos);
++
++            // regex: (?i:'s|'t|'re|'ve|'m|'ll|'d) // case insensitive
++            if (cpt == '\'' && pos+1 < offset_end) {
++                uint32_t cpt_next = unicode_tolower(_get_cpt(pos+1));
++                if (cpt_next == 's' || cpt_next == 't' || cpt_next == 'm' || cpt_next == 'd') {
++                    pos += _add_token(pos+2);
++                    continue;
++                }
++                if (pos+2 < offset_end) {
++                    uint32_t cpt_next_next = unicode_tolower(_get_cpt(pos+2));
++                    if ((cpt_next == 'r' && cpt_next_next == 'e') ||
++                        (cpt_next == 'v' && cpt_next_next == 'e') ||
++                        (cpt_next == 'l' && cpt_next_next == 'l')) {
++                        pos += _add_token(pos+3);
++                        continue;
++                    }
++                }
++            }
++
++            // regex: [^\r\n\p{L}\p{N}]?(?:\p{L}|\p{M}|\u200C|\u200D)+
++            if (!(cpt == '\r' || cpt == '\n' || flags.is_number)) {
++                if (_is_k2_letter(pos) || _is_k2_letter(pos+1)) {  // one or more letters/marks/ZWNJ/ZWJ
++                    pos++;
++                    while (_is_k2_letter(pos)) {
++                        pos++;
++                    }
++                    _add_token(pos);
++                    continue;
++                }
++            }
++
++            // regex: \p{N}{1,3}
++            if (flags.is_number) {
++                size_t ini = pos;
++                while (_get_flags(pos).is_number) {
++                    if (++pos - ini >= 3 ) {
++                        _add_token(pos);
++                        ini = pos;
++                    }
++                }
++                _add_token(pos);
++                continue;
++            }
++
++            // regex: <space>?[^\s\p{L}\p{N}]+[\r\n]*
++            auto flags2 = (cpt == ' ' ? _get_flags(pos+1) : flags);
++            if (!(flags2.is_whitespace | flags2.is_letter | flags2.is_number) && flags.as_uint()) {
++                pos += (cpt == ' ');
++                while (!(flags2.is_whitespace | flags2.is_letter | flags2.is_number) && flags2.as_uint()) {
++                    flags2 = _get_flags(++pos);
++                }
++                uint32_t cpt2 = _get_cpt(pos);
++                while (cpt2 == '\r' || cpt2 == '\n') {
++                    cpt2 = _get_cpt(++pos);
++                }
++                _add_token(pos);
++                continue;
++            }
++
++            size_t num_whitespaces = 0;
++            size_t last_end_r_or_n = 0;
++            while (_get_flags(pos+num_whitespaces).is_whitespace) {
++                uint32_t cpt2 = _get_cpt(pos+num_whitespaces);
++                if (cpt2 == '\r' || cpt2 == '\n') {
++                    last_end_r_or_n = pos + num_whitespaces + 1;
++                }
++                num_whitespaces++;
++            }
++
++            // regex: \s*[\r\n]+
++            if (last_end_r_or_n > 0) {
++                pos = last_end_r_or_n;
++                _add_token(pos);
++                continue;
++            }
++
++            // regex: \s+(?!\S)
++            if (num_whitespaces > 1 && _get_cpt(pos+num_whitespaces) != OUT_OF_RANGE) {
++                pos += num_whitespaces - 1;
++                _add_token(pos);
++                continue;
++            }
++
++            // regex: \s+
++            if (num_whitespaces > 0) {
++                pos += num_whitespaces;
++                _add_token(pos);
++                continue;
++            }
++
++            // no matches
++            _add_token(++pos);
++        }
++    }
++
++    return bpe_offsets;
++}
++
+ // Qwen2 system regex: "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+"
+ static std::vector<size_t> unicode_regex_split_custom_qwen2(const std::string & text, const std::vector<size_t> & offsets) {
+     std::vector<size_t> bpe_offsets; // store the offset of each word
+@@ -1062,6 +1212,10 @@ static std::vector<size_t> unicode_regex_split_custom(const std::string & text,
+     } else if (
+            regex_expr == "(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\\r\\n\\p{L}\\p{N}]?[\\p{L}\\p{M}]+|\\p{N}| ?[^\\s\\p{L}\\p{M}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+") {
+         bpe_offsets = unicode_regex_split_custom_qwen35(text, offsets);
++    } else if (regex_expr == "(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\\r\\n\\p{L}\\p{N}]?(?:\\p{L}|\\p{M}|\\u200C|\\u200D)+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+") {
++        // K2-Horizon: llama3 splitter with marks + ZWNJ/ZWJ inside letter runs
++        // (the generic std::regex fallback cannot parse \p{..} on MSVC)
++        bpe_offsets = unicode_regex_split_custom_k2_horizon(text, offsets);
+     } else if (regex_expr == "\\p{Han}+") {
+         // K2's first pattern - handle all K2 patterns together
+         bpe_offsets = unicode_regex_split_custom_kimi_k2(text, offsets);


### PR DESCRIPTION
…std::regex fix)

Loading any K2-Horizon GGUF on a Windows/MSVC build of the MBZUAI-IFM llama.cpp fork failed with regex_error(error_escape) before producing a token, so that box could neither quantize nor evaluate K2 models. The k2-horizon pre-tokenizer regex uses \p{L} and \p{M}; no hand-written splitter in unicode.cpp claimed that literal, so it fell through to the general std::regex fallback -- which accepts \p{...} on libc++ (macOS) and rejects it on MSVC. A portability bug, not a bad GGUF.

notes/k2-horizon-msvc-regex.patch adds the missing splitter: the Llama-3 splitter with the letter-run rule widened to also accept accent marks and ZWNJ/ZWJ, which is the only place K2's regex differs. The std::regex fallback is then never reached for this tokenizer.

Verified on RTX 5090 / MSVC 2022 / CUDA 12.8, full wikitext-2 at ctx 512: K2-Horizon-3.7B f16 went from failing to load to PPL 11.2798, while a Qwen2.5-0.5B control held at 13.6097 -- so the fix does not disturb any existing splitter.

notes/custom-arch-onboarding.md gains the general lesson: a custom pre-tokenizer can break exactly one OS, so load a tiny GGUF of a new arch on every build host, with a known-good different-arch model as the control.