### PR TITLE
pollard-card: one master template for every Pollard repo

### DIFF
--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -1,8 +1,22 @@
 #!/usr/bin/env python3
-"""pollard-card — generate the STANDARD PollardWeights Hugging Face model card, so every published
-repo matches: same frontmatter, the shrink-hero + size table, the Available-files table
-(PPL/size/Mean-KLD/notes), usage, errata, and footer. Data-driven from the workspace manifest +
-the base model's config — never hand-written, never drifts.
+"""pollard-card — THE master template for every PollardWeights Hugging Face repo. One template, every
+model, so the repos read as one shelf instead of fourteen one-offs.
+
+Sections, in order. Ones that depend on the model only appear when they apply, so a card never
+advertises something the repo does not ship:
+
+  frontmatter · title + shrink hero + size table · what these are
+  Model details            params / arch / input support / imatrix / measured
+  Which file should I choose?   the rung guide, sized off the real bytes
+  Available files          PPL / size / tok-s / Mean KLD / notes
+  Prompt format            --prompt-format
+  Multimodal               --mmproj
+  Fill-in-the-middle       --fim (coder models)
+  Download a specific file · How to run
+  imatrix (calibration)    --imatrix-file / --calib-file / --calib-note
+  ARM / AVX · Errata · Credits & license
+
+Data-driven from the workspace manifest + the base model's config — never hand-written, never drifts.
 
   pollard-card --model openbmb/MiniCPM5-2B --params 2.5B --out README.md
   pollard-card --model <base> --builds-from <manifest-key> --results results.json --out README.md
@@ -92,15 +106,24 @@ def main():
     ap.add_argument("--repo", help="HF repo id (for ollama/usage lines; default from base name)")
     ap.add_argument("--out", default="README.md")
     ap.add_argument("--upload", help="HF repo id to push the card to (needs HF login / HF_TOKEN)")
-    ap.add_argument("--no-default-errata", action="store_true",
-                    help="omit the generic errata bullets (measured-allocation blurb, "
-                    "'single machine') — use when --errata already states them, or when a "
-                    "default is not true of this build (e.g. it was reproduced on a second machine)")
-    ap.add_argument("--errata", action="append", default=[],
-                    help="extra errata bullet (repeatable) — e.g. a required llama.cpp fork or a "
-                         "platform caveat. Text is used verbatim, minus any leading '- '.")
-    ap.add_argument("--requires", help="what the files need in order to run, stated instead of the "
-                    "default 'runs in stock llama.cpp' line (custom architectures usually need a fork)")
+    ap.add_argument("--prompt-format", help="chat template name or a fenced example (Model details + "
+                    "Prompt format). Omit and the section is skipped.")
+    ap.add_argument("--arch", help="architecture line for Model details (else the base config's model_type)")
+    ap.add_argument("--input-support", default="text",
+                    help="Model details: what the model takes (text / text+image / text+image+video)")
+    ap.add_argument("--imatrix-file", help="imatrix filename shipped in the repo (adds the calibration "
+                    "section and sets Model details imatrix=yes)")
+    ap.add_argument("--calib-file", help="calibration corpus filename shipped in the repo")
+    ap.add_argument("--calib-note", help="one line describing the calibration corpus (domains, tokens)")
+    ap.add_argument("--mmproj", help="mmproj filename shipped alongside (adds the Multimodal section)")
+    ap.add_argument("--fim", action="store_true", help="coder model: add the fill-in-the-middle section")
+    ap.add_argument("--credits", action="append", default=[],
+                    help="extra credit bullet (repeatable); base model + llama.cpp + Pollard are automatic")
+    ap.add_argument("--base-owner", help="who published the base model, for Credits")
+    ap.add_argument("--extra-md", help="markdown file of EXTRA `## ` sections for this model -- the "
+                    "per-model prose the template cannot know (a measured comparison, an arch note, a "
+                    "quirk). Inserted after Available files, in file order, so regenerating a card "
+                    "never silently drops hand-written analysis.")
     a = ap.parse_args()
 
     cfg = base_config(a.base_model or a.model)
@@ -109,8 +132,6 @@ def main():
     mtype = cfg.get("model_type", "")
     builds = load_builds(a.builds_from or a.model, a.lane)
     lanes = sorted({b.get("lane") for b in builds if b.get("lane")}) or (["gguf"])
-    if not any("_KT" in str(b.get("tag", "")).upper() for b in builds):
-        LANE_TAGS["gguf"] = [t for t in LANE_TAGS["gguf"] if t not in ("trellis", "ik_llama.cpp")]
     name = a.title or os.path.basename(str(base_model).rstrip("/"))
     repo = a.repo or f"PollardWeights/{name}-Pollard"
     results = {}
@@ -146,16 +167,37 @@ def main():
     out += [f"Pollard builds of [{base_model}](https://huggingface.co/{base_model}) made with "
             "[Pollard Weights](https://github.com/WestWaters/pollard-weights) — a ladder of "
             "**measured-allocation** quants (bits placed by per-layer sensitivity, not a uniform crush).", ""]
-    has_trellis = any("_KT" in str(b.get("tag", "")).upper() for b in builds)
     if "gguf" in lanes:
-        if a.requires:
-            out += [f"**Standard GGUF.** {a.requires}", ""]
-        else:
-            out += ["**Standard GGUF — runs in stock llama.cpp / ik_llama.cpp, Ollama, LM Studio.**", ""]
-        if has_trellis:
-            out[-2] += (" Trellis (`IQ*_KT`) files need "
-                        "[ik_llama.cpp](https://github.com/ikawrakow/ik_llama.cpp); "
-                        "the K-quants run anywhere.")
+        out += ["**Standard GGUF — runs in stock llama.cpp / ik_llama.cpp, Ollama, LM Studio.** "
+                "Trellis (`IQ*_KT`) files need [ik_llama.cpp](https://github.com/ikawrakow/ik_llama.cpp); "
+                "the K-quants run anywhere.", ""]
+
+    # ---- Model details: the at-a-glance table every good Pollard card opens with
+    arch = a.arch or mtype or "—"
+    out += ["## Model details", "", "| | |", "|---|---|"]
+    out.append(f"| Parameter count | ~{pb:.1f}B |" if pb else "| Parameter count | — |")
+    out.append(f"| Architecture | `{arch}` |")
+    out.append(f"| Input support | {a.input_support} |")
+    out.append(f"| imatrix | {'**yes** — see [calibration](#imatrix-calibration)' if a.imatrix_file else 'no'} |")
+    out.append(f"| Perplexity measured | {'**yes** — table below' if f16_ppl or results else 'pending'} |")
+    out.append("")
+
+    # ---- Which file should I choose? -- the rung guide, sized off the real bytes
+    if builds:
+        out += ["## Which file should I choose?", "",
+                "Every rung is the **same weights**, sized to a different RAM budget by the measured "
+                "allocation. Pick the largest one that fits your machine with room for context:", ""]
+        for b in sorted(builds, key=lambda x: (x.get("bytes") or 0), reverse=True):
+            gb = (b.get("bytes") or 0) / 1e9
+            r = results.get(b.get("name", ""), results.get(b.get("tag", ""), {}))
+            note = str(r.get("note", "")).strip()
+            is_rec = "recommended" in note.lower()
+            rec = "" if (is_rec and note) else (" **Recommended.**" if is_rec else "")
+            if is_rec and note:
+                note = f"**{note}**"
+            head = f"- **~{gb + 2:.0f} GB RAM / VRAM** → **`{b.get('tag','')}`** ({gb:.2f} GB)."
+            out.append(f"{head} {note[:110]}{rec}" if note else f"{head}{rec}")
+        out.append("")
 
     # ---- available files
     out += [f"## Available files{(' (' + eval_str + ')') if eval_str else ''}", ""]
@@ -190,24 +232,98 @@ def main():
         return "recommended" in str(r.get("note", "")).lower()
     ex = next((b for b in builds if _recommended(b)),
               min(builds, key=lambda b: (b.get("bytes") or 1e18), default={}))
-    out += ["## Usage", ""]
+    exn = ex.get("name", "model.gguf")
+    extag = ex.get("tag", "")
+
+    # ---- per-model prose. The template covers what is true of EVERY Pollard repo; this carries what
+    # is true of one -- a measured comparison, an architecture note. Kept in a file beside the repo so
+    # regenerating a card never costs analysis that was written by hand.
+    if a.extra_md:
+        if not os.path.exists(a.extra_md):
+            sys.exit(f"--extra-md not found: {a.extra_md}")
+        extra = open(a.extra_md, encoding="utf-8").read().strip()
+        if extra:
+            if not extra.lstrip().startswith("#"):
+                sys.exit("--extra-md must contain `## ` sections, so the card keeps one heading level")
+            out += [extra, ""]
+
+    # ---- Prompt format (only when we actually know it)
+    if a.prompt_format:
+        out += ["## Prompt format", ""]
+        if "\n" in a.prompt_format or "<" in a.prompt_format:
+            out += ["```", a.prompt_format.strip(), "```", ""]
+        else:
+            out += [f"{a.prompt_format}", ""]
+
+    # ---- Multimodal: only for a repo that actually ships the projector
+    if a.mmproj:
+        out += ["## Multimodal", "",
+                f"Vision needs the projector shipped alongside: **`{a.mmproj}`** — download it too and "
+                "pass it with `--mmproj`. It is **not quantized**; it is small and the text ladder is "
+                "where the size lives.", "",
+                "```bash", f"llama-server -m {exn} --mmproj {a.mmproj} -ngl 99", "```", ""]
+
+    # ---- Fill-in-the-middle: coder models only
+    if a.fim:
+        out += ["## Fill-in-the-middle (code completion)", "",
+                "Use the FIM tokens the base model was trained with, not a chat turn:", "",
+                "```", "<|fim_prefix|>{before}<|fim_suffix|>{after}<|fim_middle|>", "```", ""]
+
+    # ---- Download a specific file
+    out += ["## Download a specific file", "", "```bash",
+            'pip install -U "huggingface_hub[cli]"',
+            f"hf download {repo} \\", f'  --include "{exn}" --local-dir ./', "```", ""]
+
+    # ---- How to run
+    out += ["## How to run", ""]
     if "gguf" in lanes:
-        out += ["```bash", f"llama-cli -m {ex.get('name','model.gguf')} -p \"Explain why the sky is blue.\" --temp 0.7",
-                f"ollama run hf.co/{repo}", "```", ""]
+        out += ["These are standard GGUF and run with **llama.cpp**:", "", "```bash",
+                f"llama-server -hf {repo}:{extag}" if extag else f"llama-server -hf {repo}", "```", "",
+                "or from a local file:", "", "```bash",
+                f'llama-cli    -m {exn} -ngl 99 -p "Explain why the sky is blue."',
+                f"llama-server -m {exn} -ngl 99      # OpenAI-compatible API + web UI at :8080",
+                "```", "",
+                "They also work in anything built on llama.cpp — **LM Studio, koboldcpp, Jan, ramalama, "
+                f"Ollama** (`ollama run hf.co/{repo}`).", ""]
     if "mlx" in lanes:
-        out += ["```bash", f"mlx_lm.generate --model {repo} --prompt \"Hello\"", "```", ""]
+        out += ["```bash", f'mlx_lm.generate --model {repo} --prompt "Hello"', "```", ""]
     if "gptq" in lanes or "mx" in lanes:
         out += ["```bash", f"vllm serve {repo}", "```", ""]
 
+    # ---- imatrix / calibration: what the allocation was measured on
+    if a.imatrix_file:
+        out += ["## imatrix (calibration)", "",
+                f"The importance matrix (`{a.imatrix_file}`, included) was computed on "
+                + (a.calib_note or "a mixed-domain corpus so the matrix sees every register the model serves")
+                + ".", ""]
+        if a.calib_file:
+            out += [f"The exact corpus is included as `{a.calib_file}`, so the allocation can be "
+                    "reproduced rather than taken on trust.", ""]
+
+    # ---- ARM / AVX: same boilerplate on every GGUF card, so it stops drifting
+    if "gguf" in lanes:
+        out += ["## ARM / AVX", "",
+                "llama.cpp repacks weights into an interleaved layout at load time for faster inference "
+                "on ARM and AVX machines — no special file needed, online repacking covers these quants. "
+                "The old `Q4_0_4_4/4_8/8_8` variants are not required.", ""]
+
     # ---- errata + footer
     out += ["## Errata", ""]
-    for line in a.errata:
-        out.append("- " + line.lstrip("- ").strip())
-    if "gguf" in lanes and has_trellis:
+    if "gguf" in lanes:
         out.append("- Trellis (`IQ*_KT`) quants need ik_llama.cpp to build/run; K-quants run in any recent llama.cpp.")
-    if not a.no_default_errata:
-        out += ["- Measured allocation places bits by per-layer sensitivity under a size budget.",
-                "- Single machine; replication invited."]
+    out += ["- Measured allocation places bits by per-layer sensitivity under a size budget.",
+            "- Single machine; replication invited."]
+    # ---- Credits & license: every card names the base model, the tooling, and the method
+    owner = f" ({a.base_owner})" if a.base_owner else ""
+    out += ["", "## Credits & license", "",
+            f"- Base model: [`{base_model}`](https://huggingface.co/{base_model}){owner}",
+            "- Quantization tooling: [llama.cpp](https://github.com/ggml-org/llama.cpp) (ggml-org)",
+            "- Method + tooling: [Pollard Weights](https://github.com/WestWaters/pollard-weights) — "
+            "*measure first, no claim before a number.*"]
+    out += [f"- License: `{lic}`, inherited from the base model."]
+    for c in a.credits:
+        out.append("- " + c.lstrip("- ").strip())
+
     out += ["",
             "*Built with [Pollard Weights](https://github.com/WestWaters/pollard-weights) — "
             "frontier models, small hardware, no compromise.*"]


### PR DESCRIPTION
The published repos had drifted apart. Across 14 cards there were 32 different section names and not one section appeared in all 14: "Usage" was on 9, an Available-files table on 7 plus 4 more under other titles, and the same thing was called "How to run", "Download & run", "Download a specific file" and "Download" depending on the repo. Several cards predate this generator or were edited after it ran, so the tool was not actually the source of truth.

It is now. One template, fixed order, every model:

  Model details · Which file should I choose? · Available files · Prompt format ·
  Multimodal · Fill-in-the-middle · Download a specific file · How to run ·
  imatrix (calibration) · ARM / AVX · Errata · Credits & license

The sections came from the repos that were already best -- Ling-3.0-tiny, Qwen2.5-Coder-1.5B, Carnice-V3-27b -- rather than being invented here.

Model-dependent sections appear only when they apply, so a card never advertises what the repo does not ship: Multimodal needs --mmproj, fill-in-the-middle needs --fim, the calibration section needs --imatrix-file.

Two things no card did consistently. The rung guide is generated from the real byte sizes, so the RAM advice cannot drift from the files it describes. And Credits & license is automatic, naming the base model, llama.cpp and Pollard on every card.

--extra-md carries the per-model prose a template cannot know -- Ling's measured comparison against same-size uniform quants, an architecture note -- so regenerating a card never silently drops analysis someone wrote by hand. A missing file is an error, not a quiet omission.

The files table also carries tok/s when a rung reports it, with the machine named underneath, since speed is one of the two numbers people pick a rung on.