### PR TITLE
notes: restore the EXL3 end-to-end section dropped in the #57 merge

### DIFF
--- a/notes/glm-5.3-cluster-verification.md
+++ b/notes/glm-5.3-cluster-verification.md
@@ -61,6 +61,40 @@ than the quantization). Two things the contract should say explicitly, both meas
   only NVMe-streamed capture at a fraction of a token/s). The next same-class dataset we can produce is Hy4-preview (770B/49B
   active, 256 experts, DSA + MLA, hyperconnections) — a second 750B-class family for the routing/outlier tables.
 
+## 6. The EXL3 lane, measured end to end on GLM-5.3 (2026-09-08)
+
+The 3.2 bpw EXL3 body from the band-parallel run (`-b 3.2 -hb 6 -mb 8 -hq`, exllamav3's budgeted allocator, SmoothQuant folded,
+our 384 × 2048 in-domain rows) served on **four** GB10 nodes at TP4, against the same model's Pollard-method GPTQ int4/int8 build
+on **eight** nodes. Same probes, same day, same fleet. (The serving side needed the runtime fixes described in the companion
+serving-gotchas note before any of this could be read.)
+
+| | EXL3 3.2 bpw, 4 nodes | GPTQ int4 experts / int8 attention, 8 nodes |
+|---|---|---|
+| artifact | 292 GB, 3.21 bpw | 396 GB, experts 4.25 bpw |
+| live perplexity, 6 fixed held-out texts (4,079 tokens) | **4.831** | 4.82 – 4.84 |
+| HumanEval / HumanEval+ pass@1 (greedy, EvalPlus) | 0.957 / 0.927 | 0.963 / 0.945 |
+| MBPP / MBPP+ pass@1 | **0.979 / 0.841** | 0.971 / 0.828 |
+| correctness probe (5 checks incl. 4- and 8-way concurrent) | all passed | all passed |
+| speculative draft | in-checkpoint MTP layer, EXL3 8-bit, k=3: **2.23 accepted/step**, 74 % draft accept | separate GPTQ int8 layer-78 draft, k=5: 1.58 – 1.84 |
+| single-stream decode, mixed workload | 24.0 tok/s | 40.0 tok/s |
+| 4-stream aggregate | 58.2 tok/s (14.6 per node) | 85.2 tok/s (10.7 per node) |
+| KV | fp8, 396K tokens at gmu 0.84 (nvfp4 unsupported by the EXL3 sparse-MLA runtime) | nvfp4, 900K at gmu 0.81 |
+
+Readings for the lane:
+- **Quality parity at 25 % fewer bits per expert weight and half the nodes.** Perplexity equal to the second decimal; HumanEval+
+  −1.8 points; MBPP+ +1.3 points. This is the allocator's own allocation with no hand-tiered recipe, i.e. the configuration your
+  measurement said wins; on this model it holds at 744B.
+- **The allocator's depth heuristic is still wrong here, and it did not matter for these gates.** §F3 of the data note showed the
+  measured per-layer error peaking mid-stack (28 dB at layers 32–49 vs 35–38 dB elsewhere at 3 bits) while the allocator spends its
+  extra bit at the ends. The budget-neutral second pass (`exl3_depth_recipe.py plan`: 19 moves, 0 bytes, predicted −25 % output
+  noise) is therefore optional for quality on GLM-5.3. It remains the cleanest experiment on measured-vs-heuristic allocation at
+  fixed size; we will run it if a fleet window opens, and report either way.
+- **The in-checkpoint MTP layer at 8 bits is the best draft we have measured on any body** (2.23 accepted/step at k=3). Quantizing the
+  draft with the body, by the same method, beats a separately quantized draft — consistent with §5.
+- **Per-node efficiency favours the 3-bit lane** (+37 % aggregate tokens per node); absolute single-stream speed favours more nodes.
+- Practical: exllamav3 pads `out_features` to multiples of 128 and stores the MTP side model with an index that can point at the
+  wrong shard; both cost us boots and are written up, with the fixes, in the serving-gotchas note and `tools/exl3_fix_mtp_ehproj.py`.
+
 ## 7. Serving the Pollard body on vLLM 0.29.0 + b12x, TP8 × 8 GB10 — deploy numbers (2026-09-09)
 
 The Int4/Int8-mix GPTQ body from this method (experts int4 g128, attention/shared int8, 369 GB text-only repack) plus the


### PR DESCRIPTION
#57 and #44 each added a `## 6.` to this note -- both written by the same contributor, both real measurements, colliding only because #57 branched eleven merges back and #44 had since taken that number. Resolving the conflict kept the new section and dropped the older one, so the file jumped from 4 to 7 and the EXL3 lane result vanished from main.

Restored verbatim from 4b8e8da and renumbered so both stand: §6 is the EXL3 lane measured end to end on GLM-5.3, §7 the vLLM 0.29 serving numbers.

What had gone missing: the TP4-vs-TP8 comparison at quality parity on half the nodes (live perplexity 4.831 vs 4.82-4.84, MBPP+ 0.841 vs 0.828), the in-checkpoint MTP draft at 2.23 accepted/step -- the best draft measured on any body -- and the note that the allocator's depth heuristic is still wrong on this model and did not matter for these gates.