### PR TITLE
VERSIONING: record what shipped; move the why into notes

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -12,15 +12,35 @@ Tag every release on GitHub as `vMAJOR.MINOR.PATCH` (e.g. `v1.3.0`), matching `v
 `pyproject.toml`. Feature work lands on its own branch → PR → merge; cut a tag when a set of changes
 is green and ready.
 
+**This file records what shipped, not why or how.** Root causes, measurements and design belong in
+`notes/`; a history entry says what changed and links to the note.
+
+## Unreleased (on `main`, not yet tagged)
+
+Tools added since `v1.3.0` — **41 CLI tools** now:
+
+- `pollard-archfp` — fingerprint an architecture's layout and name the known family it is a twin of
+  (dense / MoE / MLA / DSA / hybrid linear-attention), from a GGUF or HF weights.
+- `pollard-recard` — bring already-published repos onto the master card template without losing the
+  numbers or analysis their current cards carry.
+- `pollard-errtype` — classify why a tensor will quantize badly (outlier scale spread vs concentration)
+  before building any candidate.
+- `pollard-errsrc` — attribute measured KL cost to a tensor *and* the trigger behind it, so budget goes
+  where it buys something.
+- `pollard-card` / `pollard-onboard` / `pollard-envmatch` / `pollard-serve-eval` — card generation,
+  custom-arch onboarding, environment matching, served-side evaluation.
+
+Also on `main`: `pollard-fit --tier` (pin a whole component class and spend the remaining budget),
+`pollard-calc --gpu auto` (read the installed card instead of a name table), and the one master card
+template every repo is generated from.
+
 ## History
-- **1.3.0** — EXL3 lane fixed for low-bit: root-caused the deterministic massive-activation break
-  (a single outlier input channel collapsing the trellis global scale) and fixed it with
-  `pollard-hf-smooth` (SmoothQuant preconditioning folded into the RMSNorms, exact identity) — measured
-  smoothed 4bpw PPL 8.70 ≈ 8bpw 8.28 (was 3090 broken). New tools: `pollard-mx` (MXFP4/FP8 Blackwell
-  lane), `pollard-mlx` (Apple lane — was referenced but missing), `pollard-verify` (correctness gate),
-  `pollard-doctor` (DrDiag — diagnose/predict/repair any model any lane), plus the **workspace**
-  (`pollard-ls` + `pollard_workspace`): all builds auto-organized under `$POLLARD_HOME` (default
-  `~/pollard`) with HF-card names + `MANIFEST.json`. Banned `proxy_err` (`legacy/PROXY_ERR_BANNED.md`).
-  Packaging: every tool installs (fixed `imatrix_fix_gate` + 11 missing modules), declared
-  dependencies + per-lane extras (`[convert]`/`[exl3]`/`[mlx]`/`[mx]`/`[hf]`/`[all]`), removed
-  box-specific path locks (generic on any CUDA GPU). 32 CLI tools.
+
+- **1.3.0** — EXL3 lane fixed for low-bit (root cause and measurements:
+  [`notes/exl3-massive-activation-fix.md`](notes/exl3-massive-activation-fix.md)). New tools:
+  `pollard-mx` (MXFP4/FP8 Blackwell lane), `pollard-mlx` (Apple lane), `pollard-verify` (correctness
+  gate), `pollard-doctor` (DrDiag), plus the **workspace** (`pollard-ls` + `pollard_workspace`): builds
+  auto-organized under `$POLLARD_HOME` with HF-card names + `MANIFEST.json`. Banned `proxy_err`
+  ([`legacy/PROXY_ERR_BANNED.md`](legacy/PROXY_ERR_BANNED.md)). Packaging: every tool installs,
+  declared dependencies + per-lane extras (`[convert]`/`[exl3]`/`[mlx]`/`[mx]`/`[hf]`/`[all]`), no
+  box-specific path locks.

--- a/notes/exl3-massive-activation-fix.md
+++ b/notes/exl3-massive-activation-fix.md
@@ -1,0 +1,50 @@
+# The EXL3 low-bit break: one outlier channel, and the fix
+
+This is the root-cause write-up that used to sit inside the 1.3.0 release entry in `VERSIONING.md`.
+It is a finding, not a changelog line, so it belongs here with the rest of the experiment log.
+
+## The symptom
+
+The EXL3 lane produced a broken build at low bit-width, deterministically. Not noisy, not
+occasionally — the same collapse every run, which is what made it findable.
+
+## The cause
+
+A **single outlier input channel** collapsing the trellis global scale.
+
+A trellis quantizer fits one scale across a tensor. When one input channel carries activations orders
+of magnitude larger than the rest, that channel alone sets the scale, and every other channel is left
+quantizing inside a fraction of the available range. The result is not graceful degradation; the
+tensor's useful precision is spent representing one column.
+
+This is the "massive activation" phenomenon, and it is why the break was deterministic: the outlier is
+a property of the trained weights, not of the run.
+
+## The fix
+
+`pollard-hf-smooth` — SmoothQuant preconditioning **folded into the RMSNorms** as an exact identity.
+The per-channel scale is moved out of the activations and into the preceding norm, so the tensor the
+quantizer sees no longer has the outlier, and the model computes exactly the same function. Nothing is
+approximated: the fold is algebraically exact, which is what makes it safe to apply before measuring.
+
+## Measured
+
+| build | PPL |
+|---|---:|
+| smoothed, 4 bpw | **8.70** |
+| 8 bpw reference | 8.28 |
+| unsmoothed, 4 bpw | 3090 (broken) |
+
+Smoothed 4 bpw lands near the 8 bpw reference at half the bits. The unsmoothed number is not a
+degradation, it is a collapse — which is the point: without the fix this lane did not have a low-bit
+build at all.
+
+## Why it generalises
+
+The same shape shows up wherever one scale spans a tensor with a fat channel, so the lever is not
+EXL3-specific. `pollard-doctor` scans an fp16 source for massive-activation input channels for exactly
+this reason, and `pollard-precondition` measures whether smoothing, rotation or nothing wins for a
+given model and bit-width rather than assuming.
+
+Related: `legacy/PROXY_ERR_BANNED.md` (why a quantizer's own error estimate is not evidence) ·
+`notes/e13-measured-sensitivity-beats-uniform.md`


### PR DESCRIPTION
The 1.3.0 entry had grown into a design document. It carried the EXL3 root cause (a single outlier input channel collapsing the trellis global scale), how the fix works (SmoothQuant folded into the RMSNorms as an exact identity), and the measurements (smoothed 4 bpw 8.70 against an 8 bpw 8.28, unsmoothed 3090 = broken). That is a finding. It belongs with the experiment log, where someone looking for it would actually go, not inside a changelog line.

Moved verbatim into notes/exl3-massive-activation-fix.md, with the reasoning written out properly -- why one fat channel ruins a shared scale, why the break was deterministic rather than flaky, and why folding into the norm is safe to apply before measuring. The history entry now says what changed and links to it.

The file also said "32 CLI tools" while the repo ships 41, so anyone reading it was told something untrue. Added an Unreleased section listing what is on main but not yet tagged -- archfp, recard, errtype, errsrc, card, onboard, envmatch, serve-eval, plus --tier and --gpu auto -- and the count now matches pyproject.

No version bump: the tag still describes 1.3.0, and what is on main is honestly labelled as untagged rather than backdated into a release that did not contain it.