### PR TITLE
pollard-card: read the license off the base model's card, never defau…

### DIFF
--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -301,6 +301,35 @@ def test_alloc_granular_protects_down():
     assert F.BPW[dg] > F.BPW[gg], f"granular must protect down above gate/up, got gate={gg} down={dg}"
 
 
+def test_card_license_is_never_invented():
+    """A card's license line is a legal claim about someone else's weights, so the template must
+    read it, not default it. The old code asked `config.json` -- which almost never carries a
+    license -- and fell through to a hardcoded "apache-2.0", which published Ling-3.0-tiny (MIT)
+    under the wrong license. An unresolvable base must come back None so the tool warns.
+    """
+    import pollard_card as C
+
+    # config wins when it actually carries one
+    assert C.base_license("whoever/whatever", {"license": "mit"}) == "mit"
+
+    # a local checkout resolves from the card frontmatter, not from a default
+    d = tempfile.mkdtemp()
+    with open(os.path.join(d, "README.md"), "w", encoding="utf-8") as fh:
+        fh.write("---\nlicense: mit\npipeline_tag: text-generation\n---\n# hi\n")
+    assert C.base_license(d, {}) == "mit", "must read the frontmatter of a local base model"
+
+    # frontmatter with no license must not invent one
+    d2 = tempfile.mkdtemp()
+    with open(os.path.join(d2, "README.md"), "w", encoding="utf-8") as fh:
+        fh.write("---\npipeline_tag: text-generation\n---\n# hi\n")
+    assert C.base_license(d2, {}) is None, "no license present must resolve to None, not a guess"
+
+    # and the module must not carry a fallback license string anywhere
+    src = open(os.path.join(os.path.dirname(__file__), "..", "tools", "pollard_card.py"),
+               encoding="utf-8").read()
+    assert "apache-2.0" not in src, "pollard_card must not hardcode any license"
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -28,6 +28,7 @@ manifest key (e.g. the f16 GGUF path). Sizes/bpw come from the manifest."""
 import argparse
 import json
 import os
+import re
 import sys
 
 LANE_TAGS = {"gguf": ["gguf", "llama.cpp", "ik_llama.cpp", "trellis", "imatrix"],
@@ -46,6 +47,54 @@ def base_config(model_id):
         return json.load(open(hf_hub_download(model_id, "config.json")))
     except Exception:
         return {}
+
+
+def _frontmatter_license(path):
+    """Read `license:` out of a model card's YAML frontmatter."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            if fh.readline().strip() != "---":
+                return None
+            for line in fh:
+                if line.strip() == "---":
+                    return None
+                m = re.match(r"license:\s*(\S+)", line)
+                if m:
+                    return m.group(1).strip("\"'")
+    except OSError:
+        pass
+    return None
+
+
+def _hub_license(model_id):
+    """Ask the Hub for a model's declared license, over stdlib.
+
+    Deliberately not via `huggingface_hub`: reading one public metadata field should not require the
+    `[hf]` extra, and when that import is missing the alternative is guessing.
+    """
+    import urllib.request
+    try:
+        req = urllib.request.Request(f"https://huggingface.co/api/models/{model_id}",
+                                     headers={"User-Agent": "pollard-card"})
+        with urllib.request.urlopen(req, timeout=30) as fh:
+            return ((json.load(fh).get("cardData") or {}).get("license"))
+    except Exception:
+        return None
+
+
+def base_license(model_id, cfg):
+    """Resolve the base model's license.
+
+    `config.json` almost never carries a license -- the Hub keeps it in the card frontmatter -- so
+    reading config alone falls through to whatever default sits behind it and labels every card the
+    same regardless of the base. Ask the card first, and return None rather than guessing: the
+    license line is a legal claim about someone else's weights.
+    """
+    if cfg.get("license"):
+        return cfg["license"]
+    if os.path.isdir(model_id):
+        return _frontmatter_license(os.path.join(model_id, "README.md"))
+    return _hub_license(model_id)
 
 
 def load_builds(key, lane=None):
@@ -99,7 +148,7 @@ def main():
     ap.add_argument("--base-model", help="base_model for the frontmatter (default: --model)")
     ap.add_argument("--title", help="card title (default: basename of base model)")
     ap.add_argument("--params", help="param count, e.g. 2.5B (else estimated from config)")
-    ap.add_argument("--license", dest="license_", help="license (else from base config)")
+    ap.add_argument("--license", dest="license_", help="license (else read off the base model's card)")
     ap.add_argument("--lane", help="only this lane's builds")
     ap.add_argument("--results", help="JSON: {file_or_tag: {ppl, kld, tps, note}} + optional "
                     "{_eval, _f16_ppl, _hw}. `tps` adds a tok/s column; `_hw` names the machine.")
@@ -128,7 +177,12 @@ def main():
 
     cfg = base_config(a.base_model or a.model)
     base_model = a.base_model or a.model
-    lic = a.license_ or cfg.get("license") or "apache-2.0"
+    lic = a.license_ or base_license(base_model, cfg)
+    if not lic:
+        lic = "other"
+        print(f"WARNING: could not resolve the license of {base_model}. Wrote `other`; pass "
+              f"--license to set it. A card must not guess -- it is a legal claim about "
+              f"someone else's weights.", file=sys.stderr)
     mtype = cfg.get("model_type", "")
     builds = load_builds(a.builds_from or a.model, a.lane)
     lanes = sorted({b.get("lane") for b in builds if b.get("lane")}) or (["gguf"])


### PR DESCRIPTION
…lt it

The license line is the one thing on a card that is a claim about someone else's weights, and it was the one field nothing measured. base_config() reads the base model's config.json, and config.json essentially never carries a license -- the Hub keeps it in the card frontmatter. So `cfg.get("license")` returned None for every model we have ever built and the expression fell through to its trailing default. Every card said apache-2.0 regardless of what the base actually is.

Caught publishing FrogMini-14B, whose base (microsoft/FrogMini-14B-2510) is MIT. Checking the rest of the shelf against each base turned up one already-live repo with the same wrong line: Ling-3.0-tiny is MIT too. Both cards now say mit.

base_license() asks the base model's card -- frontmatter for a local checkout, the Hub's model metadata otherwise -- and returns None when it cannot tell. main() then writes `other` and warns on stderr instead of picking something plausible, so an unresolved license is visible rather than silent.

The Hub lookup is stdlib urllib, not huggingface_hub, on purpose: reading one public metadata field should not require the [hf] extra, and when that import is absent the only alternative left is guessing. Resolved correctly against every base we ship -- FrogMini and Ling-3.0-tiny mit, Qwen2.5/Qwen3/K2-Horizon/ MiniCPM5/Carnice apache-2.0 -- and to None for a model id that does not exist.

test_card_license_is_never_invented covers the three paths that matter offline (config wins, local frontmatter is read, a card with no license resolves to None) and asserts no license string is hardcoded in the module at all, so this cannot quietly come back.