### PR TITLE
pollard-ggufcheck: an unknown architecture makes a file fork-only too

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -27,8 +27,10 @@ Tools added since `v1.3.0` — **45 CLI tools** now:
   before building any candidate.
 - `pollard-errsrc` — attribute measured KL cost to a tensor *and* the trigger behind it, so budget goes
   where it buys something.
-- `pollard-ggufcheck` — report which runtime a GGUF needs from its tensor types rather than its name,
-  locally or against a published repo; exits non-zero so it works as a pre-publish gate.
+- `pollard-ggufcheck` — report which runtime a GGUF needs from its header rather than its name: both
+  the tensor types (stock llama.cpp rejects any ggml type above 42) and `general.architecture` (checked
+  against upstream's 146). Either alone can make a file fork-only. Exits non-zero, so it works as a
+  pre-publish gate.
 - `pollard-reclaim` — free the disk a finished model still holds, but only once the published copy is
   proven identical (matched by exact length, then confirmed head/middle/tail against the Hub). Reports
   by default; deleting is opt-in, and sources are a separate opt-in again.

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -330,8 +330,13 @@ def test_card_license_is_never_invented():
     assert "apache-2.0" not in src, "pollard_card must not hardcode any license"
 
 
-def _mini_gguf(types, path=None):
-    """Write a minimal GGUF with one tensor per entry in `types` (ggml type ids)."""
+def _mini_gguf(types, path=None, arch=b"llama"):
+    """Write a minimal GGUF with one tensor per entry in `types` (ggml type ids).
+
+    The architecture is a real upstream one by default: pollard-ggufcheck rejects an unknown
+    `general.architecture` on its own, so a placeholder here would make every atom assertion fail for
+    the wrong reason.
+    """
     import struct
     path = path or tempfile.NamedTemporaryFile(suffix=".gguf", delete=False).name
     with open(path, "wb") as fh:
@@ -339,11 +344,12 @@ def _mini_gguf(types, path=None):
         fh.write(struct.pack("<I", 3))                 # version
         fh.write(struct.pack("<Q", len(types)))        # tensor count
         fh.write(struct.pack("<Q", 1))                 # one kv pair
-        # kv: "general.architecture" (type 8 = string) -> "test"
+        # kv: general.architecture -> a REAL upstream architecture, so this fixture exercises the
+        # atom check without tripping the separate architecture check
         k = b"general.architecture"
         fh.write(struct.pack("<Q", len(k))); fh.write(k)
         fh.write(struct.pack("<I", 8))
-        fh.write(struct.pack("<Q", 4)); fh.write(b"test")
+        fh.write(struct.pack("<Q", len(arch))); fh.write(arch)
         for i, t in enumerate(types):
             n = f"blk.{i}.weight".encode()
             fh.write(struct.pack("<Q", len(n))); fh.write(n)
@@ -552,6 +558,31 @@ def test_refcheck_flags_a_broken_forward():
     # hy_v4 is on record with the expected value the gate compares against
     assert "hy_v4" in RC.KNOWN_DEFECTS
     assert RC.KNOWN_DEFECTS["hy_v4"]["expect_nll"] < RC.NLL_SUSPECT
+
+
+def test_ggufcheck_catches_a_fork_only_architecture():
+    """Stock-only atoms are not enough: the architecture string has to be one stock llama.cpp knows.
+
+    `general.architecture` is checked by name against upstream's LLM_ARCH_NAMES. A brand-new model
+    whose support lives in a vendor fork produces a file of perfectly ordinary K-quants that opens
+    nowhere else -- which is what all three K2-Horizon repos shipped. Every tensor is stock, the
+    tensor-type check passed them clean, and all three cards said the K-quants run anywhere.
+    """
+    import pollard_ggufcompat as gc
+
+    known = gc.stock_archs()
+    assert len(known) > 100, f"the architecture list looks wrong ({len(known)} entries)"
+    for ordinary in ("llama", "qwen2", "qwen3", "qwen3moe", "bailingmoe3", "deepseek2"):
+        assert ordinary in known, f"{ordinary} must be recognised as stock-loadable"
+
+    # the ones we actually ship that upstream does not implement
+    assert "k2-horizon" not in known, "k2-horizon is not an upstream architecture"
+    assert "k2-horizon" in gc.FORK_ARCHS, "a fork-only architecture must record where it IS supported"
+    name, url = gc.FORK_ARCHS["k2-horizon"]
+    assert "MBZUAI" in name and url.startswith("https://"), (name, url)
+
+    # `clip` is a quantize-only dummy and must not be offered as a loadable architecture
+    assert "clip" not in known
 
 
 def main():

--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -128,9 +128,18 @@ def build_runtimes(builds, repo=None):
             src = f"https://huggingface.co/{repo}/resolve/main/{b.get('name') or os.path.basename(path)}"
             where = "the published copy"
         try:
-            out[path] = gc.runtime_of(src)[0]
+            verdict, reasons = gc.runtime_of(src)
+            out[path] = verdict
+            if isinstance(reasons, dict) and reasons.get("supported_by"):
+                url = reasons.get("supported_url")
+                out.setdefault("_supported_by",
+                               f"[{reasons['supported_by']}]({url})" if url else reasons["supported_by"])
+                out.setdefault("_supported_plain", reasons["supported_by"])
+            arch = reasons.get("architecture") if isinstance(reasons, dict) else None
+            if arch:
+                out.setdefault("_fork_arch", arch)
         except Exception as e:                                            # noqa: BLE001
-            print(f"WARNING: could not read tensor types from {os.path.basename(path)} via {where} "
+            print(f"WARNING: could not read the header of {os.path.basename(path)} via {where} "
                   f"({e}); the card will not state a runtime for it.", file=sys.stderr)
     return out
 
@@ -237,7 +246,14 @@ def main():
     f16_ppl = results.get("_f16_ppl")
 
     runtimes = build_runtimes(builds, repo if a.runtime_from_repo else None)
-    ik_builds = [b for b in builds if runtimes.get(b.get("path")) == "ik_llama"]
+    # A rung can fail stock llama.cpp two ways -- a fork-only atom, or a fork-only architecture -- and
+    # the card has to name which. `k2-horizon` is not among upstream's 146 architectures, so all three
+    # K2 repos shipped ordinary K-quants that still open nowhere but the IFM fork.
+    fork_arch = runtimes.get("_fork_arch")
+    fork_where = runtimes.get("_supported_by")
+    fork_plain = runtimes.get("_supported_plain") or "a vendor fork"
+    runtimes = {k: v for k, v in runtimes.items() if not k.startswith("_")}
+    ik_builds = [b for b in builds if runtimes.get(b.get("path")) in ("ik_llama", "fork")]
 
     pb = parse_params_b(a.params, cfg)
     f16_gb = pb * 2.0
@@ -279,9 +295,16 @@ def main():
             out += ["**Standard GGUF — every file here runs in stock llama.cpp / ik_llama.cpp, "
                     "Ollama, LM Studio.**", ""]
         elif len(ik_builds) == len(runtimes):
-            out += [f"**These files need [ik_llama.cpp]({IK_URL}).** The measured allocation places "
-                    "ik_llama-only atoms on this model's sensitive tensors, so stock llama.cpp "
-                    "(and therefore Ollama and LM Studio) will not load them.", ""]
+            if fork_arch:
+                where = fork_where or "the vendor's llama.cpp fork"
+                out += [f"**These files need {where}.** This model's architecture "
+                        f"(`{fork_arch}`) is not one upstream llama.cpp knows, so stock llama.cpp -- "
+                        "and therefore Ollama and LM Studio -- cannot load them whatever the quant "
+                        "types are. The quants themselves are ordinary K-quants.", ""]
+            else:
+                out += [f"**These files need [ik_llama.cpp]({IK_URL}).** The measured allocation "
+                        "places ik_llama-only atoms on this model's sensitive tensors, so stock "
+                        "llama.cpp (and therefore Ollama and LM Studio) will not load them.", ""]
         else:
             need = ", ".join(f"`{b.get('tag') or b.get('name')}`" for b in
                              sorted(ik_builds, key=lambda x: -(x.get("bytes") or 0)))
@@ -315,8 +338,11 @@ def main():
             head = f"- **~{gb + 2:.0f} GB RAM / VRAM** → **`{b.get('tag','')}`** ({gb:.2f} GB)."
             # This list is where people actually pick a file, so a rung that stock llama.cpp cannot
             # open has to say so here too -- not only in the table further down.
-            if runtimes.get(b.get("path")) == "ik_llama":
+            rtb = runtimes.get(b.get("path"))
+            if rtb == "ik_llama":
                 head += " *(ik_llama.cpp)*"
+            elif rtb == "fork":
+                head += f" *(needs {fork_plain})*"
             out.append(f"{head} {note[:110]}{rec}" if note else f"{head}{rec}")
         out.append("")
 
@@ -342,7 +368,9 @@ def main():
         r = results.get(b.get("name", ""), results.get(b.get("tag", ""), {}))
         tps_c = f" {r.get('tps','—')} |" if has_tps else ""
         rt = runtimes.get(b.get("path"))
-        rt_c = (" " + ("ik_llama" if rt == "ik_llama" else "any llama.cpp" if rt else "—") + " |") if mixed else ""
+        rt_lbl = {"ik_llama": "ik_llama", "fork": fork_plain,
+                  "stock": "any llama.cpp"}.get(rt, "—")
+        rt_c = (" " + rt_lbl + " |") if mixed else ""
         out.append(f"| `{b.get('name','-')}` | {r.get('ppl','—')} | {human_gb(b.get('bytes'))} |{tps_c} "
                    f"{r.get('kld','—')} |{rt_c} {r.get('note', b.get('tag',''))} |")
     if has_tps:
@@ -410,7 +438,7 @@ def main():
         # recommended rung is ik_llama-only, showing it behind a stock `llama-server -hf` sends
         # people to a load error -- so the stock example moves to a rung that loads, and the
         # recommended one is shown with the build it needs.
-        ex_ik = runtimes.get(ex.get("path")) == "ik_llama"
+        ex_ik = runtimes.get(ex.get("path")) in ("ik_llama", "fork")
         stock = [b for b in builds if runtimes.get(b.get("path")) == "stock"]
         stock_pick = max(stock, key=lambda b: (b.get("bytes") or 0), default=None)
         if not ex_ik:
@@ -423,8 +451,12 @@ def main():
             out += ["They also work in anything built on llama.cpp — **LM Studio, koboldcpp, Jan, "
                     f"ramalama, Ollama** (`ollama run hf.co/{repo}`).", ""]
         else:
-            out += [f"`{extag or exn}` is built on ik_llama-only atoms, so it runs with "
-                    "**[ik_llama.cpp](https://github.com/ikawrakow/ik_llama.cpp)**:", "", "```bash",
+            lead = (f"This model's architecture (`{fork_arch}`) needs "
+                    f"{fork_where or 'the vendor llama.cpp fork'}, so every file here runs there"
+                    if fork_arch else
+                    f"`{extag or exn}` is built on ik_llama-only atoms, so it runs with "
+                    "**[ik_llama.cpp](https://github.com/ikawrakow/ik_llama.cpp)**")
+            out += [lead + ":", "", "```bash",
                     f'llama-cli    -m {exn} -ngl 99 -p "Explain why the sky is blue."',
                     f"llama-server -m {exn} -ngl 99", "```", ""]
             if stock_pick:
@@ -460,7 +492,13 @@ def main():
     # ---- errata + footer
     out += ["## Errata", ""]
     if "gguf" in lanes:
-        if ik_builds:
+        if ik_builds and fork_arch:
+            out.append(f"- `general.architecture` is `{fork_arch}`, which upstream llama.cpp does not "
+                       f"implement, so these files load only in "
+                       f"{fork_where or 'the vendor fork that adds it'} — the quant types are "
+                       "ordinary and irrelevant to that. Checked with `pollard-ggufcheck`, which "
+                       "reads the architecture and the tensor types out of the header.")
+        elif ik_builds:
             names = ", ".join(f"`{b.get('tag') or b.get('name')}`" for b in
                               sorted(ik_builds, key=lambda x: -(x.get("bytes") or 0)))
             out.append(f"- {names} carry ik_llama-only atoms and need ik_llama.cpp to run; "

--- a/tools/pollard_ggufcompat.py
+++ b/tools/pollard_ggufcompat.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
 """pollard-ggufcheck — which runtime can actually load a GGUF we built?
 
-A file's name does not decide this; its tensor types do. Stock llama.cpp rejects any ggml type id
-above 42 outright, so one protected tensor carrying an ik_llama-only atom makes the whole file
-ik_llama-only -- even when every other tensor is a plain K-quant and the filename says `IQ4_XS`.
+A file's name does not decide this. Two things in its header do, and either one alone is enough to
+make a file unloadable in stock llama.cpp:
 
-That is easy to ship by accident, because the measured allocation is *supposed* to reach for a
-better atom on a sensitive tensor. It just has to be said on the card.
+  * **tensor types.** Stock rejects any ggml type id above 42 outright, so one protected tensor
+    carrying an ik_llama-only atom makes the whole file ik_llama-only -- even when every other tensor
+    is a plain K-quant and the filename says `IQ4_XS`. Easy to ship by accident, because the measured
+    allocation is *supposed* to reach for a better atom on a sensitive tensor.
+  * **the architecture string.** `general.architecture` must be one stock knows. A brand-new model
+    whose support lives only in a vendor fork produces a file with perfectly ordinary K-quants that
+    still cannot open anywhere else. Our K2-Horizon repos shipped exactly that: `k2-horizon` is not
+    among upstream's 146 architectures, every tensor is stock, and all three cards said the K-quants
+    run anywhere.
+
+Either way the fix is the same -- say so on the card.
 
   pollard-ggufcheck model.gguf [more.gguf ...]      # local files
   pollard-ggufcheck --repo PollardWeights/<Model>   # a published repo, over range requests
@@ -21,6 +29,59 @@ import sys
 
 # Highest ggml type id stock llama.cpp knows. Anything above is a fork-only atom.
 STOCK_MAX = 42
+
+# Architectures upstream llama.cpp can load, snapshotted from LLM_ARCH_NAMES in
+# runtime/llama.cpp/src/llama-arch.cpp (146 entries; `clip` dropped -- it is a quantize-only dummy).
+# A vendored checkout is read in preference to this list when one is present, so a newer runtime is
+# believed over the snapshot.
+STOCK_ARCHS = {
+    "afmoe", "apertus", "arcee", "arctic", "arwkv7", "baichuan", "bailingmoe", "bailingmoe2",
+    "bailingmoe3", "bert", "bitnet", "bloom", "chameleon", "chatglm", "codeshell", "cogvlm",
+    "cohere2", "cohere2moe", "command-r", "dbrx", "deci", "deepseek", "deepseek2",
+    "deepseek2-ocr", "deepseek32", "deepseek4", "dflash", "dots1", "dots3note", "dream",
+    "eagle3", "ernie4_5", "ernie4_5-moe", "eurobert", "exaone", "exaone-moe", "exaone4",
+    "falcon", "falcon-h1", "gemma", "gemma-embedding", "gemma2", "gemma3", "gemma3n", "gemma4",
+    "gemma4-assistant", "glm-dsa", "glm4", "glm4moe", "gpt-oss", "gpt2", "gptj", "gptneox",
+    "granite", "granite_swa", "granitehybrid", "granitemoe", "graniteswitch", "grok", "grovemoe",
+    "hunyuan-dense", "hunyuan-moe", "hunyuan_vl", "hy_v3", "internlm2", "jais", "jais2", "jamba",
+    "jina-bert-v2", "jina-bert-v3", "kimi-k3", "kimi-linear", "laguna", "lfm2", "lfm2moe",
+    "llada", "llada-moe", "llama", "llama-embed", "llama4", "maincoder", "mamba", "mamba2",
+    "mellum", "mimo2", "minicpm", "minicpm3", "minimax-01", "minimax-m2", "minimax-m3",
+    "mistral3", "mistral4", "modern-bert", "mpt", "muse-glimmer", "nanbeige", "nemotron",
+    "nemotron_h", "nemotron_h_moe", "neo-bert", "nomic-bert", "nomic-bert-moe", "olmo", "olmo2",
+    "olmoe", "openelm", "orion", "paddleocr", "pangu-embedded", "phi2", "phi3", "phimoe",
+    "plamo", "plamo2", "plamo3", "plm", "pockettts", "qwen", "qwen2", "qwen2moe", "qwen2vl",
+    "qwen3", "qwen35", "qwen35moe", "qwen3moe", "qwen3next", "qwen3tts", "qwen3vl", "qwen3vlmoe",
+    "refact", "rnd1", "rwkv6", "rwkv6qwen2", "rwkv7", "seed_oss", "smallthinker", "smollm3",
+    "stablelm", "starcoder", "starcoder2", "step35", "t5", "t5encoder", "talkie",
+    "wavtokenizer-dec", "xverse"
+}
+
+# Architectures Pollard can build that stock cannot load, and where support actually lives.
+# name, url -- kept apart so a card can render a link and a console line can render plain text.
+FORK_ARCHS = {
+    "k2-horizon": ("the MBZUAI-IFM llama.cpp fork", "https://github.com/MBZUAI-IFM/llama.cpp"),
+}
+
+
+def stock_archs(vendored="runtime/llama.cpp/src/llama-arch.cpp"):
+    """The architecture names stock llama.cpp knows.
+
+    Prefers a vendored checkout so a fresher runtime wins over the snapshot; falls back to the
+    snapshot when the source is not there (an installed tool usually has no runtime beside it).
+    """
+    try:
+        import re as _re
+        src = open(vendored, encoding="utf-8").read()
+        m = _re.search(r"LLM_ARCH_NAMES\s*=\s*\{(.*?)\n\};", src, _re.S)
+        if m:
+            got = set(_re.findall(r'"\s*([a-z0-9._\-]+)\s*"', m.group(1)))
+            if len(got) > 50:                    # sanity: a real list, not a stray match
+                return got - {"clip"}
+    except OSError:
+        pass
+    return set(STOCK_ARCHS)
+
 
 STOCK_NAMES = {0: "F32", 1: "F16", 2: "Q4_0", 3: "Q4_1", 6: "Q5_0", 7: "Q5_1", 8: "Q8_0", 9: "Q8_1",
                10: "Q2_K", 11: "Q3_K", 12: "Q4_K", 13: "Q5_K", 14: "Q6_K", 15: "Q8_K",
@@ -101,6 +162,13 @@ class _Rdr:
     def u64(self): return struct.unpack("<Q", self.take(8))[0]
     def s(self): return self.take(self.u64()).decode("utf-8", "replace")
 
+    def read_value(self, t):
+        """Read a metadata value (strings only; everything else is skipped and returns None)."""
+        if t == 8:
+            return self.s()
+        self.skip_value(t)
+        return None
+
     def skip_value(self, t):
         fixed = {0: 1, 1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 1, 10: 8, 11: 8, 12: 8}
         if t == 8:
@@ -118,8 +186,8 @@ class _Rdr:
         self.take(fixed[t])
 
 
-def tensor_types(path_or_url):
-    """{ggml type id: tensor count} for a GGUF, local path or http(s) URL.
+def read_header(path_or_url):
+    """(architecture, {ggml type id: tensor count}) for a GGUF, local path or http(s) URL.
 
     Raises ValueError when the magic is wrong -- which is itself worth catching, since a file whose
     header is missing will not load anywhere no matter what the card says.
@@ -133,8 +201,12 @@ def tensor_types(path_or_url):
             raise ValueError(f"not a GGUF: magic is {magic!r}, expected b'GGUF'")
         r.u32()                                     # version
         ntensor, nkv = r.u64(), r.u64()
+        arch = ""
         for _ in range(nkv):
-            r.s(); r.skip_value(r.u32())
+            key = r.s()
+            val = r.read_value(r.u32())
+            if key == "general.architecture" and val:
+                arch = val
         counts = {}
         for _ in range(ntensor):
             r.s()
@@ -142,9 +214,14 @@ def tensor_types(path_or_url):
                 r.u64()                             # dims
             t = r.u32(); r.u64()                     # type, offset
             counts[t] = counts.get(t, 0) + 1
-        return counts
+        return arch, counts
     finally:
         src.close()
+
+
+def tensor_types(path_or_url):
+    """{ggml type id: tensor count} -- kept for callers that only care about atoms."""
+    return read_header(path_or_url)[1]
 
 
 def fork_only(counts):
@@ -152,10 +229,24 @@ def fork_only(counts):
     return {type_name(t): n for t, n in sorted(counts.items()) if t > STOCK_MAX}
 
 
-def runtime_of(path_or_url):
-    """('stock'|'ik_llama', {atom: count}) -- which runtime this file needs, and why."""
-    fo = fork_only(tensor_types(path_or_url))
-    return ("ik_llama" if fo else "stock"), fo
+def runtime_of(path_or_url, archs=None):
+    """('stock'|'ik_llama'|'fork', reasons) -- which runtime this file needs, and why.
+
+    `reasons` is a dict: fork-only atoms by name, plus an "architecture" key when
+    `general.architecture` is one stock llama.cpp does not know. Either is disqualifying on its own,
+    and the architecture is the one a tensor-type check alone cannot see.
+    """
+    arch, counts = read_header(path_or_url)
+    reasons = fork_only(counts)
+    known = archs if archs is not None else stock_archs()
+    if arch and arch not in known:
+        reasons = dict(reasons)
+        reasons["architecture"] = arch
+        where = FORK_ARCHS.get(arch)
+        if where:
+            reasons["supported_by"], reasons["supported_url"] = where
+        return "fork", reasons
+    return ("ik_llama" if reasons else "stock"), reasons
 
 
 def main():
@@ -190,21 +281,38 @@ def main():
             if not a.json:
                 print(f"  UNREADABLE  {name}\n              {e}")
             continue
-        rows.append({"file": name, "runtime": rt, "fork_only": fo})
-        if rt == "ik_llama":
+        rows.append({"file": name, "runtime": rt, "reasons": fo})
+        if rt != "stock":
             rc = 1
         if not a.json:
-            why = "  [" + ", ".join(f"{k} x{v}" for k, v in fo.items()) + "]" if fo else ""
-            print(f"  {'needs ik_llama' if fo else 'stock llama.cpp':<16}  {name}{why}")
+            arch = fo.get("architecture")
+            atoms = ", ".join(f"{k} x{v}" for k, v in fo.items()
+                              if k not in ("architecture", "supported_by", "supported_url"))
+            if arch:
+                label = "needs a fork"
+                bits = [f"architecture `{arch}` is not one stock llama.cpp knows"]
+                if fo.get("supported_by"):
+                    bits.append(f"supported by {fo['supported_by']} ({fo.get('supported_url','')})"
+                                .replace(" ()", ""))
+                if atoms:
+                    bits.append(f"also fork-only atoms: {atoms}")
+                why = "  [" + "; ".join(bits) + "]"
+            elif atoms:
+                label, why = "needs ik_llama", f"  [{atoms}]"
+            else:
+                label, why = "stock llama.cpp", ""
+            print(f"  {label:<16}  {name}{why}")
 
     if a.json:
         print(json.dumps(rows, indent=1))
     else:
-        need = [r for r in rows if r.get("runtime") == "ik_llama"]
+        ik = [r for r in rows if r.get("runtime") == "ik_llama"]
+        fk = [r for r in rows if r.get("runtime") == "fork"]
         bad = [r for r in rows if r.get("error")]
-        print(f"\n{len(rows)} file(s): {len(rows)-len(need)-len(bad)} stock, {len(need)} ik_llama"
+        print(f"\n{len(rows)} file(s): {len(rows)-len(ik)-len(fk)-len(bad)} stock, {len(ik)} ik_llama"
+              + (f", {len(fk)} fork-only architecture" if fk else "")
               + (f", {len(bad)} unreadable" if bad else ""))
-        if need:
+        if ik or fk:
             print("Say so on the card: these will not load in stock llama.cpp, Ollama or LM Studio.")
     return rc
 


### PR DESCRIPTION
The atom check missed the simpler way a Pollard GGUF fails to open: its `general.architecture` has to be one stock llama.cpp implements. A brand-new model whose support lives in a vendor fork produces a file of perfectly ordinary K-quants that opens nowhere else.

All three K2-Horizon repos shipped exactly that. Every tensor type is stock, so the earlier scan passed them clean, and all three cards said "Standard GGUF - runs in stock llama.cpp / ik_llama.cpp, Ollama, LM Studio", offered `llama-server -hf <repo>:IQ3_S`, and told people `ollama run hf.co/...`. But `k2-horizon` is not among upstream's 146 architectures (LLM_ARCH_NAMES in runtime/llama.cpp/src/llama-arch.cpp), so none of that works anywhere but the MBZUAI-IFM fork.

This is the same lesson as the rope-pairing defect from a different direction: what a file needs is in its header, and the header has two independent answers.

read_header() now returns the architecture alongside the type histogram, checked against a snapshot of upstream's list -- preferring a vendored checkout when one is present, so a newer runtime is believed over the snapshot. runtime_of() returns 'fork' with the offending architecture and where support actually lives, and FORK_ARCHS records that per architecture rather than leaving a reader guessing.

pollard-card states it wherever it already stated the ik_llama case: the line above the ladder, the chooser bullets, the runs-in column, the run commands and the errata -- naming the fork and saying plainly that the quant types are ordinary and irrelevant to the problem. Regenerated the three K2 cards; checked FrogMini (all stock) and Qwen2.5-7B (mixed atoms) are unchanged.

Scanning the shelf with the architecture check turned up a fourth repo: Spark-X2.5-4B-Pollard declares `spark2_5`, which no llama.cpp checkout on either machine implements -- not the IFM fork, not ik_llama, not llama-stq, not the vendored runtime. Its card carries real perplexity numbers, so something loaded those files once. Being chased separately; not addressed here.

The test fixture had to change with this: it wrote general.architecture = "test", which the new check correctly rejects, so every atom assertion was failing for the wrong reason. It writes a real architecture now, which is the point.