### PR TITLE
pollard-ggufcheck: "not in my list" is not "needs a fork"

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -28,9 +28,10 @@ Tools added since `v1.3.0` — **45 CLI tools** now:
 - `pollard-errsrc` — attribute measured KL cost to a tensor *and* the trigger behind it, so budget goes
   where it buys something.
 - `pollard-ggufcheck` — report which runtime a GGUF needs from its header rather than its name: both
-  the tensor types (stock llama.cpp rejects any ggml type above 42) and `general.architecture` (checked
-  against upstream's 146). Either alone can make a file fork-only. Exits non-zero, so it works as a
-  pre-publish gate.
+  the tensor types (stock llama.cpp rejects any ggml type above 42) and `general.architecture`. Either
+  alone can stop a file loading. It separates "your llama.cpp is older than this architecture" from
+  "no upstream support exists", asking ggml-org master rather than trusting a snapshot, and says
+  nothing at all when it cannot check. Exits non-zero, so it works as a pre-publish gate.
 - `pollard-reclaim` — free the disk a finished model still holds, but only once the published copy is
   proven identical (matched by exact length, then confirmed head/middle/tail against the Hub). Reports
   by default; deleting is opt-in, and sources are a separate opt-in again.

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -585,6 +585,53 @@ def test_ggufcheck_catches_a_fork_only_architecture():
     assert "clip" not in known
 
 
+def test_arch_support_never_calls_a_new_architecture_a_fork():
+    """A stale architecture list must not become a claim about someone else's runtime.
+
+    The first version of this check compared against one snapshot and reported anything missing as
+    fork-only. The snapshot came from the vendored runtime, which was three entries behind master, so
+    Spark-X2.5-4B was published as needing a fork when upstream had merged `spark2_5` four days
+    earlier (llama.cpp #27868, 2026-09-06). "Update llama.cpp" and "go get someone else's build" are
+    different instructions and only one of them was true.
+
+    So a miss against the local list is the trigger to ask upstream, and there are four answers, not
+    two. Unreachable upstream must produce "unknown" -- never "fork".
+    """
+    import pollard_ggufcompat as gc
+
+    local = {"llama", "qwen2", "k2-horizon-not-this"}
+
+    # in the local list -> stock, and upstream is never consulted
+    assert gc.arch_support("llama", local=local, offline=True)[0] == "stock"
+
+    # missing locally and upstream cannot be reached -> claim nothing
+    v, why = gc.arch_support("spark2_5", local=local, offline=True)
+    assert v == "unknown", (v, why)
+    assert "no claim" in why.lower(), why
+
+    # missing locally but upstream has it -> a version requirement, not a fork
+    saved = gc._upstream_cache
+    try:
+        gc._upstream_cache = {"llama", "qwen2", "spark2_5"}
+        v2, why2 = gc.arch_support("spark2_5", local=local)
+        assert v2 == "newer", (v2, why2)
+        # and one upstream does NOT have is a fork, named
+        v3, why3 = gc.arch_support("k2-horizon", local=local)
+        assert v3 == "fork", (v3, why3)
+        assert "MBZUAI" in why3, why3
+    finally:
+        gc._upstream_cache = saved
+
+    # the shipped snapshot must be at least as new as the architectures we publish against
+    assert "spark2_5" in gc.STOCK_ARCHS, "the snapshot is stale again"
+    assert "k2-horizon" not in gc.STOCK_ARCHS, "k2-horizon is not upstream"
+
+    # the atom tables must survive any future edit to the architecture block -- they were once
+    # deleted by a rewrite of it, which silently made every atom verdict raise
+    assert gc.type_name(140) == "IQ5_K" and gc.type_name(23) == "IQ4_XS"
+    assert gc.fork_only({0: 1, 23: 10, 140: 28}) == {"IQ5_K": 28}
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -138,6 +138,7 @@ def build_runtimes(builds, repo=None):
             arch = reasons.get("architecture") if isinstance(reasons, dict) else None
             if arch:
                 out.setdefault("_fork_arch", arch)
+                out.setdefault("_arch_verdict", verdict)
         except Exception as e:                                            # noqa: BLE001
             print(f"WARNING: could not read the header of {os.path.basename(path)} via {where} "
                   f"({e}); the card will not state a runtime for it.", file=sys.stderr)
@@ -250,10 +251,20 @@ def main():
     # the card has to name which. `k2-horizon` is not among upstream's 146 architectures, so all three
     # K2 repos shipped ordinary K-quants that still open nowhere but the IFM fork.
     fork_arch = runtimes.get("_fork_arch")
+    # 'newer' and 'fork' are different promises to a reader: one is "update llama.cpp", the other is
+    # "you need someone else's build". Conflating them once told people Spark-X2.5 needed a fork when
+    # upstream had merged the architecture days earlier.
+    arch_verdict = runtimes.get("_arch_verdict")
     fork_where = runtimes.get("_supported_by")
     fork_plain = runtimes.get("_supported_plain") or "a vendor fork"
+    if arch_verdict == "newer":
+        fork_where = "a current llama.cpp"
+        fork_plain = "a current llama.cpp"
     runtimes = {k: v for k, v in runtimes.items() if not k.startswith("_")}
-    ik_builds = [b for b in builds if runtimes.get(b.get("path")) in ("ik_llama", "fork")]
+    # Anything that is not plainly 'stock' has to be said on the card. 'newer' and 'unknown' belong
+    # here too: a reader whose llama.cpp cannot open the file does not care why it cannot.
+    NONSTOCK = ("ik_llama", "fork", "newer", "unknown")
+    ik_builds = [b for b in builds if runtimes.get(b.get("path")) in NONSTOCK]
 
     pb = parse_params_b(a.params, cfg)
     f16_gb = pb * 2.0
@@ -295,7 +306,13 @@ def main():
             out += ["**Standard GGUF — every file here runs in stock llama.cpp / ik_llama.cpp, "
                     "Ollama, LM Studio.**", ""]
         elif len(ik_builds) == len(runtimes):
-            if fork_arch:
+            if fork_arch and arch_verdict == "newer":
+                out += [f"**Standard GGUF, but you need a recent llama.cpp.** This model's "
+                        f"architecture (`{fork_arch}`) is implemented upstream, so any build new "
+                        "enough to carry it runs these files -- llama.cpp itself, and Ollama or "
+                        "LM Studio once they ship a runtime with it. An older build will refuse them "
+                        "with `unknown model architecture`. The quants are ordinary K-quants.", ""]
+            elif fork_arch:
                 where = fork_where or "the vendor's llama.cpp fork"
                 out += [f"**These files need {where}.** This model's architecture "
                         f"(`{fork_arch}`) is not one upstream llama.cpp knows, so stock llama.cpp -- "
@@ -341,7 +358,7 @@ def main():
             rtb = runtimes.get(b.get("path"))
             if rtb == "ik_llama":
                 head += " *(ik_llama.cpp)*"
-            elif rtb == "fork":
+            elif rtb in ("fork", "newer", "unknown"):
                 head += f" *(needs {fork_plain})*"
             out.append(f"{head} {note[:110]}{rec}" if note else f"{head}{rec}")
         out.append("")
@@ -368,8 +385,8 @@ def main():
         r = results.get(b.get("name", ""), results.get(b.get("tag", ""), {}))
         tps_c = f" {r.get('tps','—')} |" if has_tps else ""
         rt = runtimes.get(b.get("path"))
-        rt_lbl = {"ik_llama": "ik_llama", "fork": fork_plain,
-                  "stock": "any llama.cpp"}.get(rt, "—")
+        rt_lbl = {"ik_llama": "ik_llama", "fork": fork_plain, "newer": fork_plain,
+                  "unknown": "unverified", "stock": "any llama.cpp"}.get(rt, "—")
         rt_c = (" " + rt_lbl + " |") if mixed else ""
         out.append(f"| `{b.get('name','-')}` | {r.get('ppl','—')} | {human_gb(b.get('bytes'))} |{tps_c} "
                    f"{r.get('kld','—')} |{rt_c} {r.get('note', b.get('tag',''))} |")
@@ -438,7 +455,7 @@ def main():
         # recommended rung is ik_llama-only, showing it behind a stock `llama-server -hf` sends
         # people to a load error -- so the stock example moves to a rung that loads, and the
         # recommended one is shown with the build it needs.
-        ex_ik = runtimes.get(ex.get("path")) in ("ik_llama", "fork")
+        ex_ik = runtimes.get(ex.get("path")) in NONSTOCK
         stock = [b for b in builds if runtimes.get(b.get("path")) == "stock"]
         stock_pick = max(stock, key=lambda b: (b.get("bytes") or 0), default=None)
         if not ex_ik:
@@ -451,7 +468,10 @@ def main():
             out += ["They also work in anything built on llama.cpp — **LM Studio, koboldcpp, Jan, "
                     f"ramalama, Ollama** (`ollama run hf.co/{repo}`).", ""]
         else:
-            lead = (f"This model's architecture (`{fork_arch}`) needs "
+            lead = (f"This model's architecture (`{fork_arch}`) needs a llama.cpp new enough to "
+                    "carry it, so build or update from upstream first"
+                    if fork_arch and arch_verdict == "newer" else
+                    f"This model's architecture (`{fork_arch}`) needs "
                     f"{fork_where or 'the vendor llama.cpp fork'}, so every file here runs there"
                     if fork_arch else
                     f"`{extag or exn}` is built on ik_llama-only atoms, so it runs with "
@@ -464,6 +484,9 @@ def main():
                 out += [f"For stock llama.cpp, Ollama or LM Studio, use `{st or sn}` instead:", "",
                         "```bash", f"llama-server -hf {repo}:{st}" if st else f"llama-server -hf {repo}",
                         f'llama-cli    -m {sn} -ngl 99 -p "Explain why the sky is blue."', "```", ""]
+            elif arch_verdict == "newer":
+                out += ["Ollama and LM Studio will run these once their bundled llama.cpp carries "
+                        f"`{fork_arch}`.", ""]
             else:
                 out += ["No rung in this repo loads in stock llama.cpp, so Ollama and LM Studio "
                         "cannot run these files.", ""]
@@ -492,7 +515,13 @@ def main():
     # ---- errata + footer
     out += ["## Errata", ""]
     if "gguf" in lanes:
-        if ik_builds and fork_arch:
+        if ik_builds and fork_arch and arch_verdict == "newer":
+            out.append(f"- `general.architecture` is `{fork_arch}`, which upstream llama.cpp added "
+                       "recently. A build older than that support refuses these files with `unknown "
+                       "model architecture` — update llama.cpp rather than looking for a different "
+                       "quant. Checked with `pollard-ggufcheck`, which reads the architecture and the "
+                       "tensor types out of the header and asks upstream what it implements.")
+        elif ik_builds and fork_arch:
             out.append(f"- `general.architecture` is `{fork_arch}`, which upstream llama.cpp does not "
                        f"implement, so these files load only in "
                        f"{fork_where or 'the vendor fork that adds it'} — the quant types are "

--- a/tools/pollard_ggufcompat.py
+++ b/tools/pollard_ggufcompat.py
@@ -19,6 +19,7 @@ Either way the fix is the same -- say so on the card.
   pollard-ggufcheck model.gguf [more.gguf ...]      # local files
   pollard-ggufcheck --repo PollardWeights/<Model>   # a published repo, over range requests
   pollard-ggufcheck --json *.gguf                   # machine-readable
+  pollard-ggufcheck --offline model.gguf            # never consult upstream (claims less)
 
 Exit code is 1 if any file needs ik_llama, so this works as a pre-publish gate."""
 import argparse
@@ -30,10 +31,14 @@ import sys
 # Highest ggml type id stock llama.cpp knows. Anything above is a fork-only atom.
 STOCK_MAX = 42
 
-# Architectures upstream llama.cpp can load, snapshotted from LLM_ARCH_NAMES in
-# runtime/llama.cpp/src/llama-arch.cpp (146 entries; `clip` dropped -- it is a quantize-only dummy).
-# A vendored checkout is read in preference to this list when one is present, so a newer runtime is
-# believed over the snapshot.
+# Architectures upstream llama.cpp can load, snapshotted from LLM_ARCH_NAMES on ggml-org master,
+# 2026-09-10 (149 entries; `clip` dropped -- it is a quantize-only dummy).
+#
+# A SNAPSHOT GOES STALE, and stale in the dangerous direction: a new architecture that upstream has
+# merged looks fork-only, which is a claim about someone else's runtime. That already happened here --
+# a list taken from the vendored runtime was three entries behind master and reported Spark-X2.5-4B as
+# fork-only when upstream had merged `spark2_5` days earlier. So a miss against this list is not the
+# answer; it is the trigger to go and ask, which `arch_support()` does.
 STOCK_ARCHS = {
     "afmoe", "apertus", "arcee", "arctic", "arwkv7", "baichuan", "bailingmoe", "bailingmoe2",
     "bailingmoe3", "bert", "bitnet", "bloom", "chameleon", "chatglm", "codeshell", "cogvlm",
@@ -43,18 +48,18 @@ STOCK_ARCHS = {
     "falcon", "falcon-h1", "gemma", "gemma-embedding", "gemma2", "gemma3", "gemma3n", "gemma4",
     "gemma4-assistant", "glm-dsa", "glm4", "glm4moe", "gpt-oss", "gpt2", "gptj", "gptneox",
     "granite", "granite_swa", "granitehybrid", "granitemoe", "graniteswitch", "grok", "grovemoe",
-    "hunyuan-dense", "hunyuan-moe", "hunyuan_vl", "hy_v3", "internlm2", "jais", "jais2", "jamba",
-    "jina-bert-v2", "jina-bert-v3", "kimi-k3", "kimi-linear", "laguna", "lfm2", "lfm2moe",
-    "llada", "llada-moe", "llama", "llama-embed", "llama4", "maincoder", "mamba", "mamba2",
-    "mellum", "mimo2", "minicpm", "minicpm3", "minimax-01", "minimax-m2", "minimax-m3",
+    "hunyuan-dense", "hunyuan-moe", "hunyuan_vl", "hy_v3", "hy_v4", "internlm2", "jais", "jais2",
+    "jamba", "jina-bert-v2", "jina-bert-v3", "kimi-k3", "kimi-linear", "laguna", "lfm2",
+    "lfm2moe", "llada", "llada-moe", "llama", "llama-embed", "llama4", "maincoder", "mamba",
+    "mamba2", "mellum", "mimo2", "minicpm", "minicpm3", "minimax-01", "minimax-m2", "minimax-m3",
     "mistral3", "mistral4", "modern-bert", "mpt", "muse-glimmer", "nanbeige", "nemotron",
     "nemotron_h", "nemotron_h_moe", "neo-bert", "nomic-bert", "nomic-bert-moe", "olmo", "olmo2",
     "olmoe", "openelm", "orion", "paddleocr", "pangu-embedded", "phi2", "phi3", "phimoe",
     "plamo", "plamo2", "plamo3", "plm", "pockettts", "qwen", "qwen2", "qwen2moe", "qwen2vl",
     "qwen3", "qwen35", "qwen35moe", "qwen3moe", "qwen3next", "qwen3tts", "qwen3vl", "qwen3vlmoe",
-    "refact", "rnd1", "rwkv6", "rwkv6qwen2", "rwkv7", "seed_oss", "smallthinker", "smollm3",
-    "stablelm", "starcoder", "starcoder2", "step35", "t5", "t5encoder", "talkie",
-    "wavtokenizer-dec", "xverse"
+    "qwen4exp", "refact", "rnd1", "rwkv6", "rwkv6qwen2", "rwkv7", "seed_oss", "smallthinker",
+    "smollm3", "spark2_5", "stablelm", "starcoder", "starcoder2", "step35", "t5", "t5encoder",
+    "talkie", "wavtokenizer-dec", "xverse"
 }
 
 # Architectures Pollard can build that stock cannot load, and where support actually lives.
@@ -65,10 +70,11 @@ FORK_ARCHS = {
 
 
 def stock_archs(vendored="runtime/llama.cpp/src/llama-arch.cpp"):
-    """The architecture names stock llama.cpp knows.
+    """The architecture names the llama.cpp BESIDE US knows.
 
-    Prefers a vendored checkout so a fresher runtime wins over the snapshot; falls back to the
-    snapshot when the source is not there (an installed tool usually has no runtime beside it).
+    Prefers a vendored checkout, because that is the runtime this machine would actually build and run
+    with. Falls back to the snapshot when there is no source to read (an installed tool usually has no
+    runtime next to it). This is a local fact, not a claim about upstream -- see arch_support().
     """
     try:
         import re as _re
@@ -81,6 +87,60 @@ def stock_archs(vendored="runtime/llama.cpp/src/llama-arch.cpp"):
     except OSError:
         pass
     return set(STOCK_ARCHS)
+
+
+_UPSTREAM_URL = "https://raw.githubusercontent.com/ggml-org/llama.cpp/master/src/llama-arch.cpp"
+_upstream_cache = None
+
+
+def upstream_archs(offline=False):
+    """What ggml-org master implements right now, or None if it could not be read.
+
+    None matters: it means "unknown", and an unknown must never be reported as a fork-only
+    architecture. Cached per process -- one fetch however many files are checked.
+    """
+    global _upstream_cache
+    if offline:
+        return None
+    if _upstream_cache is not None:
+        return _upstream_cache or None
+    try:
+        import re as _re
+        import urllib.request
+        req = urllib.request.Request(_UPSTREAM_URL, headers={"User-Agent": "pollard-ggufcheck"})
+        with urllib.request.urlopen(req, timeout=45) as fh:
+            src = fh.read().decode("utf-8", "replace")
+        m = _re.search(r"LLM_ARCH_NAMES\s*=\s*\{(.*?)\n\};", src, _re.S)
+        got = set(_re.findall(r'"\s*([a-z0-9._\-]+)\s*"', m.group(1))) - {"clip"} if m else set()
+        _upstream_cache = got if len(got) > 50 else set()
+    except Exception:
+        _upstream_cache = set()
+    return _upstream_cache or None
+
+
+def arch_support(arch, local=None, offline=False):
+    """('stock'|'newer'|'fork'|'unknown', detail) for an architecture name.
+
+    Three different answers that a single list cannot tell apart, and conflating them makes a false
+    claim about someone else's runtime:
+
+      stock   the llama.cpp here already knows it
+      newer   upstream has merged it, the runtime here is behind -- the user needs a newer llama.cpp,
+              not a fork
+      fork    upstream does not implement it at all; support lives somewhere specific
+      unknown the local list misses it and upstream could not be consulted -- say so, claim nothing
+    """
+    known = stock_archs() if local is None else local
+    if not arch or arch in known:
+        return "stock", ""
+    up = upstream_archs(offline=offline)
+    if up is None:
+        return "unknown", ("not in the llama.cpp here, and upstream could not be checked "
+                           "(offline?) -- no claim made")
+    if arch in up:
+        return "newer", "upstream llama.cpp implements it; the build here is older"
+    where = FORK_ARCHS.get(arch)
+    return "fork", (where[0] if where else "no upstream support and no fork on record")
 
 
 STOCK_NAMES = {0: "F32", 1: "F16", 2: "Q4_0", 3: "Q4_1", 6: "Q5_0", 7: "Q5_1", 8: "Q8_0", 9: "Q8_1",
@@ -229,23 +289,30 @@ def fork_only(counts):
     return {type_name(t): n for t, n in sorted(counts.items()) if t > STOCK_MAX}
 
 
-def runtime_of(path_or_url, archs=None):
-    """('stock'|'ik_llama'|'fork', reasons) -- which runtime this file needs, and why.
+def runtime_of(path_or_url, archs=None, offline=False):
+    """('stock'|'ik_llama'|'newer'|'fork'|'unknown', reasons) -- what this file needs, and why.
 
-    `reasons` is a dict: fork-only atoms by name, plus an "architecture" key when
-    `general.architecture` is one stock llama.cpp does not know. Either is disqualifying on its own,
-    and the architecture is the one a tensor-type check alone cannot see.
+    Two independent disqualifiers live in a GGUF header and a tensor-type check sees only one:
+
+      * a fork-only atom (any ggml type above 42)      -> 'ik_llama'
+      * an architecture the local llama.cpp lacks       -> resolved by arch_support(), which
+        separates "upstream merged it, you are behind" from "no upstream support at all"
+
+    The architecture answer takes precedence when it is disqualifying, because no quant type can
+    rescue a file whose architecture will not load.
     """
     arch, counts = read_header(path_or_url)
     reasons = fork_only(counts)
-    known = archs if archs is not None else stock_archs()
-    if arch and arch not in known:
+    verdict, detail = arch_support(arch, local=archs, offline=offline)
+    if verdict != "stock":
         reasons = dict(reasons)
         reasons["architecture"] = arch
-        where = FORK_ARCHS.get(arch)
-        if where:
-            reasons["supported_by"], reasons["supported_url"] = where
-        return "fork", reasons
+        reasons["arch_detail"] = detail
+        if verdict == "fork":
+            where = FORK_ARCHS.get(arch)
+            if where:
+                reasons["supported_by"], reasons["supported_url"] = where
+        return verdict, reasons
     return ("ik_llama" if reasons else "stock"), reasons
 
 
@@ -256,6 +323,10 @@ def main():
     ap.add_argument("files", nargs="*", help="GGUF paths (or URLs)")
     ap.add_argument("--repo", help="check every .gguf in a published HF repo instead")
     ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--offline", action="store_true",
+                    help="do not ask upstream what it implements. An architecture missing from the "
+                         "local list then reports as unverified instead of being called fork-only -- "
+                         "a stale list must not turn into a claim about someone else's runtime")
     a = ap.parse_args()
 
     targets = list(a.files)
@@ -274,7 +345,7 @@ def main():
     for t in targets:
         name = os.path.basename(str(t).split("?")[0])
         try:
-            rt, fo = runtime_of(t)
+            rt, fo = runtime_of(t, offline=a.offline)
         except Exception as e:                                            # noqa: BLE001
             rows.append({"file": name, "error": str(e)})
             rc = 1
@@ -283,14 +354,16 @@ def main():
             continue
         rows.append({"file": name, "runtime": rt, "reasons": fo})
         if rt != "stock":
-            rc = 1
+            rc = 1                     # 'newer' counts: the runtime here still cannot open it
         if not a.json:
             arch = fo.get("architecture")
             atoms = ", ".join(f"{k} x{v}" for k, v in fo.items()
-                              if k not in ("architecture", "supported_by", "supported_url"))
+                              if k not in ("architecture", "supported_by", "supported_url",
+                                           "arch_detail"))
             if arch:
-                label = "needs a fork"
-                bits = [f"architecture `{arch}` is not one stock llama.cpp knows"]
+                label = {"newer": "needs newer llama.cpp", "fork": "needs a fork",
+                         "unknown": "cannot verify"}.get(rt, "needs a fork")
+                bits = [f"architecture `{arch}`: {fo.get('arch_detail','')}".rstrip(": ")]
                 if fo.get("supported_by"):
                     bits.append(f"supported by {fo['supported_by']} ({fo.get('supported_url','')})"
                                 .replace(" ()", ""))
@@ -306,14 +379,18 @@ def main():
     if a.json:
         print(json.dumps(rows, indent=1))
     else:
-        ik = [r for r in rows if r.get("runtime") == "ik_llama"]
-        fk = [r for r in rows if r.get("runtime") == "fork"]
-        bad = [r for r in rows if r.get("error")]
-        print(f"\n{len(rows)} file(s): {len(rows)-len(ik)-len(fk)-len(bad)} stock, {len(ik)} ik_llama"
-              + (f", {len(fk)} fork-only architecture" if fk else "")
-              + (f", {len(bad)} unreadable" if bad else ""))
-        if ik or fk:
+        by = {}
+        for r in rows:
+            by.setdefault(r.get("runtime") or "error", []).append(r)
+        parts = [f"{len(v)} {k}" for k, v in sorted(by.items())]
+        print(f"\n{len(rows)} file(s): " + ", ".join(parts))
+        if by.get("newer"):
+            print("Say so on the card: these need a llama.cpp new enough to carry the architecture. "
+                  "That is a version requirement, NOT a fork.")
+        if by.get("ik_llama") or by.get("fork"):
             print("Say so on the card: these will not load in stock llama.cpp, Ollama or LM Studio.")
+        if by.get("unknown"):
+            print("Could not reach upstream to confirm an unrecognised architecture; nothing claimed.")
     return rc
 
 


### PR DESCRIPTION
I shipped a bug in the architecture check and it made a false claim about someone else's runtime.

The check compared `general.architecture` against one snapshot and reported anything missing as fork-only. The snapshot came from the vendored runtime, which was three entries behind master. So Spark-X2.5-4B came back fork-only when upstream had merged `spark2_5` four days earlier -- llama.cpp #27868, merged 2026-09-06 -- and the honest instruction for that repo is "update llama.cpp", not "go and get somebody else's build".

I caught it by checking my own conclusion against ggml-org master instead of the vendored tree, which is where the K2 finding should also have been checked. K2 survives that: `k2-horizon` is still not among master's 149 architectures, so those three cards are right as published.

A miss against the local list is now the trigger to ask, not the answer. arch_support() returns four things where there were two:

  stock    the llama.cpp here already knows it
  newer    upstream implements it; this build is behind -> a version requirement
  fork     upstream does not implement it -> name where support lives
  unknown  local miss and upstream unreachable -> say so, claim nothing

--offline forces the last case. The snapshot is refreshed from master (149) and carries a date and a note saying plainly that a snapshot goes stale in the dangerous direction.

pollard-card now words those separately. Spark's card says the architecture is implemented upstream, that an older build refuses it with `unknown model architecture`, and that Ollama and LM Studio will run it once their bundled llama.cpp carries it -- instead of sending people to a fork that does not need to exist. K2's card is unchanged. FrogMini (all stock) and Qwen2.5-7B (mixed atoms, IQ5_K on 28 attn_v) are unchanged.

Two things this broke that the tests now hold:

- 'newer' and 'unknown' were missing from the card's non-stock set, so a file the local runtime cannot open was described as running everywhere. A reader whose llama.cpp refuses the file does not care why.
- rewriting the architecture block deleted STOCK_NAMES and IK_NAMES, which made every atom verdict raise. Qwen2.5-7B briefly reported all-stock because of it. The test now asserts type_name(140) == "IQ5_K" and that fork_only still finds it, so an edit to one block cannot silently disable the other.