### PR TITLE
pollard-runtime --install: a synced repo can still be missing its com…

### DIFF
--- a/runtime-patches/README.md
+++ b/runtime-patches/README.md
@@ -58,3 +58,17 @@ used to print a bare `git pull`, which was advice that could destroy a published
 **A patched tree is not updated in place.** The trees carrying local support (`ifm-llama`,
 `ik_llama.cpp`, `llama-stq`) are pinned to the bases their patches were written against. A current
 upstream runtime is a SEPARATE clone, so nothing a pull does can reach the patched trees.
+
+## After a sync that adds a tool
+
+Syncing the repo updates the code but not the commands. An editable install resolves modules straight
+into the checkout, so `import pollard_card` is always current, but pip only writes command launchers
+when it runs — so a newly added tool exists and its command does not.
+
+```bash
+pollard-runtime --install        # does the install run what the repo declares?
+```
+
+Non-zero means a declared command has no launcher, and it prints the exact `pip install -e` to fix it.
+Run that wherever Pollard is installed. Every tool added in one session was in that state on both
+machines, and nothing surfaced it until someone typed a name that did not exist.

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -713,6 +713,33 @@ def test_runtime_patch_verification_survives_line_ending_drift():
     assert R._added_lines("+++ b/x\n+\n+real\n") == {"real"}
 
 
+def test_install_state_catches_a_declared_but_uninstalled_command():
+    """A synced repo can still be missing the command for a tool it declares.
+
+    An editable install keeps module code current -- `import pollard_card` resolves straight into the
+    checkout -- but pip only writes command launchers when it runs. Add a tool, sync, and the code is
+    there while the command is not, which nobody notices until they type the name. Every tool added in
+    one session sat in exactly that state on both machines.
+    """
+    import pollard_runtime as R
+
+    d = tempfile.mkdtemp()
+    with open(os.path.join(d, "pyproject.toml"), "w", encoding="utf-8") as fh:
+        fh.write('[project]\nname = "x"\n\n[project.scripts]\n'
+                 'pollard-alpha = "a:main"\npollard-beta = "b:main"\n')
+    got = R.declared_scripts(d)
+    assert got == {"pollard-alpha": "a:main", "pollard-beta": "b:main"}, got
+
+    st = R.install_state(d)
+    assert st is not None
+    assert set(st["declared"]) == {"pollard-alpha", "pollard-beta"}
+    # this interpreter has neither, so both must be reported missing rather than assumed fine
+    assert set(st["missing"]) == {"pollard-alpha", "pollard-beta"}, st["missing"]
+
+    # no pyproject at all is "cannot tell", not "all good"
+    assert R.install_state(tempfile.mkdtemp()) is None
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_runtime.py
+++ b/tools/pollard_runtime.py
@@ -201,6 +201,48 @@ def published_archs(owner="PollardWeights"):
     return out
 
 
+def declared_scripts(repo_root="."):
+    """Console scripts pyproject declares, as {command: module}."""
+    try:
+        import tomllib
+    except ImportError:                                                    # py<3.11
+        return {}
+    try:
+        with open(os.path.join(repo_root, "pyproject.toml"), "rb") as fh:
+            d = tomllib.load(fh)
+        return dict(d.get("project", {}).get("scripts", {}))
+    except Exception:                                                      # noqa: BLE001
+        return {}
+
+
+def installed_scripts():
+    """Command launchers actually present next to the running interpreter."""
+    bindir = os.path.dirname(sys.executable)
+    out = set()
+    for f in os.listdir(bindir) if os.path.isdir(bindir) else []:
+        name = f[:-4] if f.lower().endswith(".exe") else f
+        if name.startswith("pollard"):
+            out.add(name)
+    return out
+
+
+def install_state(repo_root="."):
+    """Is the install able to RUN what the repo declares?
+
+    An editable install keeps module code current automatically -- `import pollard_card` resolves
+    straight into the checkout -- but it only writes command launchers when pip runs. So adding a tool
+    and syncing leaves the code present and the command missing, which is invisible until someone types
+    the name. Every tool added in one session was in exactly that state on both machines.
+    """
+    declared = declared_scripts(repo_root)
+    if not declared:
+        return None
+    present = installed_scripts()
+    missing = sorted(c for c in declared if c not in present)
+    return {"declared": sorted(declared), "present": sorted(present), "missing": missing,
+            "bindir": os.path.dirname(sys.executable)}
+
+
 PATCH_DIR = "runtime-patches"
 
 
@@ -367,6 +409,11 @@ def main():
                          "binaries); non-zero if any has been lost")
     ap.add_argument("--apply", metavar="NAME", help="re-apply a captured patch after a clone or reset")
     ap.add_argument("--patch-dir", default=PATCH_DIR, help=f"where patches live (default {PATCH_DIR})")
+    ap.add_argument("--install", action="store_true",
+                    help="check the install can RUN what the repo declares -- an editable install "
+                         "keeps module code current but only writes command launchers when pip runs, "
+                         "so a synced repo can still have missing commands. Non-zero if any is")
+    ap.add_argument("--repo-root", default=".", help="repo to read pyproject.toml from")
     ap.add_argument("--dirty", action="store_true",
                     help="just list trees with uncommitted changes -- runtime work that is not yet "
                          "an artifact and would be lost by a checkout")
@@ -377,6 +424,25 @@ def main():
     if not trees:
         print("no llama.cpp trees found. Pass --scan <dir>.")
         return 0
+
+    if a.install:
+        st = install_state(a.repo_root)
+        if st is None:
+            print(f"could not read {os.path.join(a.repo_root, 'pyproject.toml')} — pass --repo-root")
+            return 0
+        print(f"interpreter : {sys.executable}")
+        print(f"launchers in: {st['bindir']}")
+        print(f"declared    : {len(st['declared'])}")
+        print(f"present     : {len(st['present'])}")
+        if not st["missing"]:
+            print("\nevery declared command is installed.")
+            return 0
+        print(f"\nMISSING {len(st['missing'])} command(s) — the code is there, the launcher is not:")
+        for c in st["missing"]:
+            print(f"   {c}")
+        print(f"\nfix: {sys.executable} -m pip install -e {os.path.abspath(a.repo_root)} --no-deps")
+        print("Run that wherever Pollard is installed after a sync that adds a tool.")
+        return 1
 
     if a.dirty:
         rc = 0


### PR DESCRIPTION
…mands

Syncing the boxes updates the code, not the commands. Pollard is installed editable on both machines pointing at the checkout, so module code is always current -- `import pollard_card` resolves straight into the repo. But pip only writes command launchers when it runs, so adding a tool and syncing leaves the code present and the command absent.

Every tool added in one session was in that state on both machines: pollard-runtime, pollard-reclaim, pollard-refcheck, pollard-ggufcheck and pollard-exl3-band all had working modules and no command. Nothing surfaced it, because I had been invoking module paths directly the whole time. Both are reinstalled now, 46 of 46 declared commands present on each.

--install compares what pyproject declares against the launchers beside the running interpreter and exits non-zero when one is missing, printing the exact `pip install -e` to run. Verified both directions: clean on a fresh venv, and it correctly reports a declared-but-uninstalled command when one is added.

This belongs next to the runtime checks because it is the same failure shape -- a thing under Pollard going stale with nothing watching, invisible until a build or a command fails for a reason that looks unrelated.

Pollard also now has its own venv on the Mac (~/pollard-venv) instead of living in the Vespiro harness venv, and has been uninstalled from that one. Vespiro is a separate project and Pollard had no business in its environment.