### PR TITLE
runtime-patches: the ik_llama capture was mostly encoding damage; rep…

### DIFF
--- a/runtime-patches/ik_llama.cpp-k2-horizon-arch.json
+++ b/runtime-patches/ik_llama.cpp-k2-horizon-arch.json
@@ -21,11 +21,10 @@
  "adds_strings": [
   "deepseek-llm",
   "k2-horizon",
-  "llama-vocab.h",
   "output",
   "output_norm",
   "rope_freqs",
   "token_embd"
  ],
- "diff_bytes": 30634
+ "diff_bytes": 14427
 }

--- a/runtime-patches/ik_llama.cpp-k2-horizon-arch.patch
+++ b/runtime-patches/ik_llama.cpp-k2-horizon-arch.patch
@@ -111,54 +111,9 @@ index 4e38a3b..4c6aa73 100644
          LLM_ARCH_MUSE_GLIMMER,
          {
 diff --git a/src/llama-vocab.cpp b/src/llama-vocab.cpp
-index edcd125..cc7f8ec 100644
+index edcd125..1494dcf 100644
 --- a/src/llama-vocab.cpp
 +++ b/src/llama-vocab.cpp
-@@ -1,4 +1,4 @@
--#include "llama-vocab.h"
-+﻿#include "llama-vocab.h"
- 
- #include "ggml.h"
- #include "llama-impl.h"
-@@ -307,10 +307,10 @@ struct llm_tokenizer_bpe : llm_tokenizer {
-             case LLAMA_VOCAB_PRE_TYPE_DEEPSEEK_LLM:
-                 regex_exprs = {
-                     "[\r\n]",
--                    "\\s?[A-Za-zµÀ-ÖØ-öø-ƺƼ-ƿǄ-ʓʕ-ʯͰ-ͳͶͷͻ-ͽͿΆΈ-ΊΌΎ-ΡΣ-ϵϷ-ҁҊ-ԯԱ-ՖႠ-ჅᎠ-Ᏽᏸ-ᏽᲐ-ᲺᲽ-Ჿᴀ-ᴫᵫ-ᵷᵹ-ᶚḀ-ἕἘ-Ἕἠ-ὅὈ-Ὅὐ-ὗὙὛὝὟ-ώᾀ-ᾴᾶ-ᾼιῂ-ῄῆ-ῌῐ-ΐῖ-Ίῠ-Ῥῲ-ῴῶ-ῼℂℇℊ-ℓℕℙ-ℝℤΩℨK-ℭℯ-ℴℹℼ-ℿⅅ-ⅉⅎↃↄⰀ-ⱻⱾ-ⳤⳫ-ⳮⳲⳳꙀ-ꙭꚀ-ꚛꜢ-ꝯꝱ-ꞇꞋ-ꞎꭰ-ꮿﬀ-ﬆﬓ-ﬗＡ-Ｚａ-ｚ𐐀-𐑏𐒰-𐓓𐓘-𐓻𐲀-𐲲𐳀-𐳲𑢠-𑣟𞤀-𞥃]+",
--                    "\\s?[!-/:-~！-／：-～‘-‟　-。]+",
-+                    "\\s?[A-Za-zÂµÃ€-Ã–Ã˜-Ã¶Ã¸-ÆºÆ¼-Æ¿Ç„-Ê“Ê•-Ê¯Í°-Í³Í¶Í·Í»-Í½Í¿Î†Îˆ-ÎŠÎŒÎŽ-Î¡Î£-ÏµÏ·-ÒÒŠ-Ô¯Ô±-Õ–á‚ -áƒ…áŽ -áµá¸-á½á²-á²ºá²½-á²¿á´€-á´«áµ«-áµ·áµ¹-á¶šá¸€-á¼•á¼˜-á¼á¼ -á½…á½ˆ-á½á½-á½—á½™á½›á½á½Ÿ-á½½á¾€-á¾´á¾¶-á¾¼á¾¾á¿‚-á¿„á¿†-á¿Œá¿-á¿“á¿–-á¿›á¿ -á¿¬á¿²-á¿´á¿¶-á¿¼â„‚â„‡â„Š-â„“â„•â„™-â„â„¤â„¦â„¨â„ª-â„­â„¯-â„´â„¹â„¼-â„¿â……-â…‰â…Žâ†ƒâ†„â°€-â±»â±¾-â³¤â³«-â³®â³²â³³ê™€-ê™­êš€-êš›êœ¢-ê¯ê±-êž‡êž‹-êžŽê­°-ê®¿ï¬€-ï¬†ï¬“-ï¬—ï¼¡-ï¼ºï½-ï½šð€-ð‘ð’°-ð““ð“˜-ð“»ð²€-ð²²ð³€-ð³²ð‘¢ -ð‘£Ÿðž¤€-ðž¥ƒ]+",
-+                    "\\s?[!-/:-~ï¼-ï¼ï¼š-ï½žâ€˜-â€Ÿã€€-ã€‚]+",
-                     "\\s+$",
--                    "[一-龥ࠀ-一가-퟿]+",
-+                    "[ä¸€-é¾¥à €-ä¸€ê°€-íŸ¿]+",
-                     "\\p{N}+",
-                 };
-                 break;
-@@ -319,13 +319,13 @@ struct llm_tokenizer_bpe : llm_tokenizer {
-             case LLAMA_VOCAB_PRE_TYPE_JOYAI_LLM:
-                 regex_exprs = {
-                     "\\p{N}{1,3}",
--                    "[一-龥぀-ゟ゠-ヿ]+",
-+                    "[ä¸€-é¾¥ã€-ã‚Ÿã‚ -ãƒ¿]+",
-                     "[!\"#$%&'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~][A-Za-z]+|[^\r\n\\p{L}\\p{P}\\p{S}]?[\\p{L}\\p{M}]+| ?[\\p{P}\\p{S}]+[\r\n]*|\\s*[\r\n]+|\\s+(?!\\S)|\\s+",
-                 };
-                 break;
-             case LLAMA_VOCAB_PRE_TYPE_YOUTU:
-                 regex_exprs = {
--                    "[가-힣ㄱ-ㆎ]+|[！…“”‘’—：；，、-〿︰-﹏]+|[ㄅ-ㄯ]+|[一-龥぀-ゟ゠-ヿ]+",
-+                    "[ê°€-íž£ã„±-ã†Ž]+|[ï¼â€¦â€œâ€â€˜â€™â€”ï¼šï¼›ï¼Œã€-ã€¿ï¸°-ï¹]+|[ã„…-ã„¯]+|[ä¸€-é¾¥ã€-ã‚Ÿã‚ -ãƒ¿]+",
-                     "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]*[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]+(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])?|[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]+[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]*(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])?|\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
-                 };
-                 break;
-@@ -334,7 +334,7 @@ struct llm_tokenizer_bpe : llm_tokenizer {
-                     "[\r\n]",
-                     "\\s?\\p{L}+",
-                     "\\s?\\p{P}+",
--                    "[一-龥ࠀ-一가-퟿]+",
-+                    "[ä¸€-é¾¥à €-ä¸€ê°€-íŸ¿]+",
-                     "\\p{N}",
-                 };
-                 break;
 @@ -369,6 +369,11 @@ struct llm_tokenizer_bpe : llm_tokenizer {
                  };
                  break;
@@ -171,42 +126,6 @@ index edcd125..cc7f8ec 100644
              case LLAMA_VOCAB_PRE_TYPE_QWEN2:
              case LLAMA_VOCAB_PRE_TYPE_HUNYUAN:
              case LLAMA_VOCAB_PRE_TYPE_SOLAR_OPEN:
-@@ -389,7 +394,7 @@ struct llm_tokenizer_bpe : llm_tokenizer {
-             case LLAMA_VOCAB_PRE_TYPE_BLOOM:
-             case LLAMA_VOCAB_PRE_TYPE_GPT3_FINNISH:
-                 regex_exprs = {
--                    " ?[^(\\s|.,!?…。，、।۔،)]+",
-+                    " ?[^(\\s|.,!?â€¦ã€‚ï¼Œã€à¥¤Û”ØŒ)]+",
-                 };
-                 break;
-             case LLAMA_VOCAB_PRE_TYPE_CHATGLM4:
-@@ -399,7 +404,7 @@ struct llm_tokenizer_bpe : llm_tokenizer {
-                 break;
-             case LLAMA_VOCAB_PRE_TYPE_VIKING:
-                 regex_exprs = {
--                    " ?[^(\\s|.,!?…。，、।۔،)]+",
-+                    " ?[^(\\s|.,!?â€¦ã€‚ï¼Œã€à¥¤Û”ØŒ)]+",
-                     "\\p{N}",
-                 };
-                 break;
-@@ -481,7 +486,7 @@ struct llm_tokenizer_bpe : llm_tokenizer {
-                     // Groups digits with leading 1-2 based on total length modulo 3
-                     "\\p{AFMoE_digits}",
-                     // CJK and Asian scripts (using direct Unicode literals)
--                    "[一-鿿㐀-䶿豈-﫿぀-ゟ゠-ヿ･-ﾟ⼀-⿟เ-๿຀-໿ក-៿က-႟ꩠ-ꩿꧠ-꧿가-힯ᄀ-ᇿ]+",
-+                    "[ä¸€-é¿¿ã€-ä¶¿è±ˆ-ï«¿ã€-ã‚Ÿã‚ -ãƒ¿ï½¥-ï¾Ÿâ¼€-â¿Ÿà¹€-à¹¿àº€-à»¿áž€-áŸ¿á€€-á‚Ÿê© -ê©¿ê§ -ê§¿ê°€-íž¯á„€-á‡¿]+",
-                     // Main BPE pattern
-                     "[!\"#$%&'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~][A-Za-z]+|[^\\r\\n\\p{L}\\p{P}\\p{S}]?[\\p{L}\\p{M}]+| ?[\\p{P}\\p{S}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
-                 };
-@@ -494,7 +499,7 @@ struct llm_tokenizer_bpe : llm_tokenizer {
-                 };
-                 break;
-             case LLAMA_VOCAB_PRE_TYPE_GEMMA4:
--                // Gemma4 uses SPM-style BPE: spaces are replaced with ▁ by the
-+                // Gemma4 uses SPM-style BPE: spaces are replaced with â– by the
-                 // normalizer, then BPE merges run on the whole text without
-                 // word-level pre-splitting. We only need to split on newlines
-                 // since BPE merge lookup asserts no newlines in tokens.
 @@ -1945,6 +1950,8 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                  LLAMA_LOG_WARN("%s: ************************************        \n", __func__);
                  LLAMA_LOG_WARN("%s:                                             \n", __func__);
@@ -216,69 +135,6 @@ index edcd125..cc7f8ec 100644
              } else if (tokenizer_pre == "default") {
                  pre_type = LLAMA_VOCAB_PRE_TYPE_DEFAULT;
              } else if (
-@@ -2370,7 +2377,7 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
-                         || t.first == "<EOT>"
-                         || t.first == "_<EOT>"
-                         || t.first == "[EOT]" // Kimi-K2
--                        || t.first == "<｜end▁of▁sentence｜>" // DeepSeek
-+                        || t.first == "<ï½œendâ–ofâ–sentenceï½œ>" // DeepSeek
-                         || t.first == "<end_of_utterance>" // smoldocling
-                    ) {
-                     special_eot_id = t.second;
-@@ -2402,9 +2409,9 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
-                         || t.first == "<|fim_prefix|>"  // Qwen
-                         || t.first == "<fim-prefix>"
-                         || t.first == "<fim_prefix>"    // Granite
--                        || t.first == "<｜fim▁begin｜>" // DeepSeek
-+                        || t.first == "<ï½œfimâ–beginï½œ>" // DeepSeek
-                         || t.first == "<PRE>"
--                        || t.first == "▁<PRE>"          // CodeLlama
-+                        || t.first == "â–<PRE>"          // CodeLlama
-                         || t.first == "<|code_prefix|>" // GLM-4.5
-                         || t.first == "<|prefix|>"      // Falcon-H1-Tiny-Coder
-                         ) {
-@@ -2423,9 +2430,9 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
-                         || t.first == "<|fim_suffix|>" // Qwen
-                         || t.first == "<fim-suffix>"
-                         || t.first == "<fim_suffix>"   // Granite
--                        || t.first == "<｜fim▁hole｜>" // DeepSeek
-+                        || t.first == "<ï½œfimâ–holeï½œ>" // DeepSeek
-                         || t.first == "<SUF>"
--                        || t.first == "▁<SUF>"         // CodeLlama
-+                        || t.first == "â–<SUF>"         // CodeLlama
-                         || t.first == "<|code_suffix|>" // GLM-4.5
-                         || t.first == "<|suffix|>"      // Falcon-H1-Tiny-Coder
-                         ) {
-@@ -2444,9 +2451,9 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
-                         || t.first == "<|fim_middle|>" // Qwen
-                         || t.first == "<fim-middle>"
-                         || t.first == "<fim_middle>"   // Granite
--                        || t.first == "<｜fim▁end｜>"  // DeepSeek
-+                        || t.first == "<ï½œfimâ–endï½œ>"  // DeepSeek
-                         || t.first == "<MID>"
--                        || t.first == "▁<MID>"         // CodeLlama
-+                        || t.first == "â–<MID>"         // CodeLlama
-                         || t.first == "<|code_middle|>" // GLM-4.5
-                         || t.first == "<|middle|>"      // Falcon-H1-Tiny-Coder
-                         ) {
-@@ -2577,7 +2584,7 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
-                     || t.first == "<eos>"            // gemma4
-                     || t.first == "<turn|>"          // gemma4
-                     || t.first == "<|tool_response>" // gemma4
--                    || t.first == "<｜end▁of▁sentence｜>" // deepseek-ocr
-+                    || t.first == "<ï½œendâ–ofâ–sentenceï½œ>" // deepseek-ocr
-                ) {
-                 special_eog_ids.insert(t.second);
-                 if ((attr & LLAMA_TOKEN_ATTR_CONTROL) == 0) {
-@@ -3332,7 +3339,7 @@ int32_t llama_vocab::impl::token_to_piece(llama_token token, char * buf, int32_t
-                 }
-                 if (attr & LLAMA_TOKEN_ATTR_NORMAL) {
-                     if (escape_whitespaces) {
--                        // SPM-style BPE: tokens contain ▁ for spaces
-+                        // SPM-style BPE: tokens contain â– for spaces
-                         std::string result = token_text;
-                         llama_unescape_whitespace(result);
-                         return _try_copy(result.data(), result.size());
 diff --git a/src/llama-vocab.h b/src/llama-vocab.h
 index 3dbf811..2ccdd59 100644
 --- a/src/llama-vocab.h
@@ -292,60 +148,9 @@ index 3dbf811..2ccdd59 100644
  
  struct LLM_KV;
 diff --git a/src/llama.cpp b/src/llama.cpp
-index d670c5f..06cfdec 100644
+index d670c5f..1f8ff71 100644
 --- a/src/llama.cpp
 +++ b/src/llama.cpp
-@@ -1,4 +1,4 @@
--//
-+﻿//
- // Copyright (C) 2023-2025 The llama.cpp authors
- // Copyright (C) 2024-2025 Iwan Kawrakow
- // MIT license
-@@ -2886,7 +2886,7 @@ static void llm_requantize_output_tensor(llama_model & model, ggml_type new_type
- // the returned tensor (data pointing into tmp_buffer) is only valid until the
- // buffers are reused, and only its type/shape/data may be used: its src chain
- // and the populated graph reference stack locals of this function, so do not
--// walk the srcs or recompute the graph — clear it with ggml_graph_clear before
-+// walk the srcs or recompute the graph â€” clear it with ggml_graph_clear before
- // reuse. ctx/graph must be able to hold the ~8 nodes of the derivation.
- // Returns null if the graph computation fails.
- static ggml_tensor * llm_compute_wkv_b(ggml_context * ctx, ggml_cgraph * graph,
-@@ -3174,7 +3174,7 @@ static void llm_prepare_mla(llama_model & model, int mla) {
-             };
- 
-             // pp_opt-favoring wk_b_pp = quantize(wk_b_f32) directly (absorb-favoring
--            // wk_b above is its transpose). Not gated on mla — wk_b_pp shares wk_b_f32
-+            // wk_b above is its transpose). Not gated on mla â€” wk_b_pp shares wk_b_f32
-             // with the wk_b synthesis above and skipping it breaks absorb on some
-             // quant combinations. Second pass below gates the mla=1 saving for
-             // GGUFs that ship wk_b directly.
-@@ -4714,7 +4714,7 @@ static bool llm_load_tensors(
- 
-     ml.done_getting_tensors();
- 
--    // --dry-run skips MAP_POPULATE/WILLNEED — tensor data is never read.
-+    // --dry-run skips MAP_POPULATE/WILLNEED â€” tensor data is never read.
-     ml.init_mappings(!defer_expert_mmap && !dry_run, use_mlock ? &model.mlock_mmaps : nullptr, ml.use_thp);
-     model.mappings.reserve(ml.mappings.size());
- 
-@@ -5139,7 +5139,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
-         // ASSUMPTION (latent today): min(pos) over the whole [0,n_kv) span equals the sequence's
-         // genuine first-present token only for a NON-SLIDING cache. GLM_DSA has no SWA, so the
-         // oldest cell of a seq is its true sink; if SWA were ever added, the window could evict the
--        // real sink and min(pos) would anchor on the wrong (window-floor) cell — revisit then.
-+        // real sink and min(pos) would anchor on the wrong (window-floor) cell â€” revisit then.
-         std::unordered_map<llama_seq_id, llama_pos> seq_min_pos;
-         for (int64_t i = 0; i < n_kv; ++i) {
-             const auto & cell = kv_self.cells[i];
-@@ -5628,7 +5628,7 @@ static void llama_set_inputs(llama_context & lctx, const llama_batch & batch) {
- 
-             // For causal models running in non-causal mode (e.g., Gemma-4 image decode),
-             // the flash-attn mask is allocated as [n_kv, n_tokens_pad] and must be filled
--            // using KV cache cell metadata — not batch-token indices — because image tokens
-+            // using KV cache cell metadata â€” not batch-token indices â€” because image tokens
-             // occupy cells starting at n_past, not at cell 0.
-             if (cparams.flash_attn && hparams.causal_attn && !lctx.is_encoding) {
-                 const ggml_half h_inf  = ggml_fp32_to_fp16(-INFINITY);
 @@ -8929,6 +8929,7 @@ enum llama_rope_type llama_rope_type(const struct llama_model * model) {
          case LLM_ARCH_GEMMA4_MTP:
          case LLM_ARCH_DFLASH_DRAFT:
@@ -354,76 +159,6 @@ index d670c5f..06cfdec 100644
          case LLM_ARCH_GEMMA4_ASSISTANT:
              return LLAMA_ROPE_TYPE_NEOX;
  
-@@ -9468,7 +9469,7 @@ int llama_spec_ckpt_init(struct llama_context * ctx, int mode, int max_tokens) {
-             : kv.checkpoint_alloc_shadows();
-     };
- 
--    // prefer PER_STEP → GPU_FALLBACK → CPU
-+    // prefer PER_STEP â†’ GPU_FALLBACK â†’ CPU
-     if (requested == LLAMA_SPEC_CKPT_AUTO) {
-         requested = LLAMA_SPEC_CKPT_PER_STEP;
-     }
-@@ -10095,7 +10096,7 @@ struct llama_data_write {
-             write_openpangu_state(ctx, seq_id, false);
-         }
- 
--        // DSV4 compressed indexer cache (only for DSV4 models — preserves
-+        // DSV4 compressed indexer cache (only for DSV4 models â€” preserves
-         // the old file layout for all other architectures)
-         if (ctx->model.arch == LLM_ARCH_DEEPSEEK4 && ctx->dsv4.cache.cache_ctx != nullptr) {
-             const uint32_t dsv4_n_layer = n_layer;
-@@ -12085,13 +12086,13 @@ static llm_chat_template llama_chat_detect_template(const std::string & tmpl) {
-         return LLM_CHAT_TEMPLATE_COMMAND_R;
-     } else if (tmpl_contains("<|start_header_id|>") && tmpl_contains("<|end_header_id|>")) {
-         return LLM_CHAT_TEMPLATE_LLAMA_3;
--    } else if (tmpl_contains(LU8("<用户>"))) {
-+    } else if (tmpl_contains(LU8("<ç”¨æˆ·>"))) {
-         // MiniCPM-3B-OpenHermes-2.5-v2-GGUF
-         return LLM_CHAT_TEMPLATE_MINICPM;
-     } else if (tmpl_contains("'Assistant: ' + message['content'] + eos_token")) {
-         return LLM_CHAT_TEMPLATE_DEEPSEEK_2;
--    } else if (tmpl_contains(LU8("<｜Assistant｜>")) && tmpl_contains(LU8("<｜User｜>")) && tmpl_contains(LU8("<｜end▁of▁sentence｜>"))) {
--         // original: if (tmpl_contains(LU8("'<｜Assistant｜>' + message['content'] + '<｜end▁of▁sentence｜>'"))) {
-+    } else if (tmpl_contains(LU8("<ï½œAssistantï½œ>")) && tmpl_contains(LU8("<ï½œUserï½œ>")) && tmpl_contains(LU8("<ï½œendâ–ofâ–sentenceï½œ>"))) {
-+         // original: if (tmpl_contains(LU8("'<ï½œAssistantï½œ>' + message['content'] + '<ï½œendâ–ofâ–sentenceï½œ>'"))) {
-         return LLM_CHAT_TEMPLATE_DEEPSEEK_3;
-     } else if (tmpl_contains("[|system|]") && tmpl_contains("[|assistant|]") && tmpl_contains("[|endofturn|]")) {
-         // ref: https://huggingface.co/LGAI-EXAONE/EXAONE-3.0-7.8B-Instruct/discussions/8#66bae61b1893d14ee8ed85bb
-@@ -12403,7 +12404,7 @@ static int32_t llama_chat_apply_template_internal(
-         for (auto message : chat) {
-             std::string role(message->role);
-             if (role == "user") {
--                ss << LU8("<用户>");
-+                ss << LU8("<ç”¨æˆ·>");
-                 ss << trim(message->content);
-                 ss << "<AI>";
-             } else {
-@@ -12419,7 +12420,7 @@ static int32_t llama_chat_apply_template_internal(
-             } else if (role == "user") {
-                 ss << "User: " << message->content << "\n\n";
-             } else if (role == "assistant") {
--                ss << "Assistant: " << message->content << LU8("<｜end▁of▁sentence｜>");
-+                ss << "Assistant: " << message->content << LU8("<ï½œendâ–ofâ–sentenceï½œ>");
-             }
-         }
-         if (add_ass) {
-@@ -12432,13 +12433,13 @@ static int32_t llama_chat_apply_template_internal(
-             if (role == "system") {
-                 ss << message->content << "\n\n";
-             } else if (role == "user") {
--                ss << LU8("<｜User｜>") << message->content;
-+                ss << LU8("<ï½œUserï½œ>") << message->content;
-             } else if (role == "assistant") {
--                ss << LU8("<｜Assistant｜>") << message->content << LU8("<｜end▁of▁sentence｜>");
-+                ss << LU8("<ï½œAssistantï½œ>") << message->content << LU8("<ï½œendâ–ofâ–sentenceï½œ>");
-             }
-         }
-         if (add_ass) {
--            ss << LU8("<｜Assistant｜>");
-+            ss << LU8("<ï½œAssistantï½œ>");
-         }
-     } else if (tmpl == LLM_CHAT_TEMPLATE_EXAONE_3) {
-         // ref: https://huggingface.co/LGAI-EXAONE/EXAONE-3.0-7.8B-Instruct/discussions/8#66bae61b1893d14ee8ed85bb
 diff --git a/src/unicode.cpp b/src/unicode.cpp
 index 19824d6..c994975 100644
 --- a/src/unicode.cpp

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -740,6 +740,33 @@ def test_install_state_catches_a_declared_but_uninstalled_command():
     assert R.install_state(tempfile.mkdtemp()) is None
 
 
+def test_capture_refuses_encoding_damage():
+    """A captured runtime patch must not smuggle encoding damage in as if it were work.
+
+    An editor that reads a UTF-8 source as Latin-1 and writes it back replaces lines with broken
+    copies of themselves. Captured, that becomes the thing you re-apply after a clone, so the damage
+    is permanent. Real case: 27 of 39 hunks in a k2-horizon capture were a byte-order mark or
+    mojibake, and the mojibake sat inside a DeepSeek pre-tokenizer regex -- any build made from that
+    patch would mis-tokenize DeepSeek models.
+    """
+    import pollard_runtime as R
+
+    good = ("diff --git a/x.c b/x.c\n--- a/x.c\n+++ b/x.c\n@@ -1,1 +1,2 @@\n"
+            " int main(void) {\n+    return 0;\n")
+    assert R.encoding_noise(good) == "", R.encoding_noise(good)
+
+    bom = "+\ufeff#include <stdio.h>\n-#include <stdio.h>\n"
+    assert "byte-order mark" in R.encoding_noise(bom)
+
+    # 'A-tilde circumflex' is how an em dash looks after a UTF-8 -> Latin-1 -> UTF-8 round trip
+    moji = "+// clear the graph \u00c3\u00a2\u00c2\u0080\u00c2\u0094 before reuse\n-// clear the graph before reuse\n"
+    assert "Latin-1" in R.encoding_noise(moji), R.encoding_noise(moji)
+
+    # a legitimate non-ASCII addition is NOT damage: real unicode in a tokenizer regex must pass
+    legit = '+        "\\s?[!-/:-~\uff01-\uff0f\u2018-\u201f\u3000-\u3002]+",\n'
+    assert R.encoding_noise(legit) == "", R.encoding_noise(legit)
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_runtime.py
+++ b/tools/pollard_runtime.py
@@ -250,6 +250,25 @@ def _slug(tree):
     return os.path.basename(os.path.abspath(tree).rstrip("/\\")) or "runtime"
 
 
+def encoding_noise(diff):
+    """Describe encoding damage in a diff, or '' if it is clean.
+
+    Two signatures: a byte-order mark on an added line, and the leading bytes of UTF-8 text that was
+    decoded as Latin-1 and re-encoded. Both replace a line with a broken copy of itself.
+    """
+    bom = "\ufeff"
+    markers = ("\u00c3\u00a2", "\u00c3\u0083", "\u00ef\u00bd", "\u00c3\u00af")
+    adds = [l for l in diff.splitlines() if l.startswith("+") and not l.startswith("+++")]
+    n_bom = sum(1 for l in adds if bom in l)
+    n_moji = sum(1 for l in adds if any(m in l for m in markers))
+    bits = []
+    if n_bom:
+        bits.append(f"{n_bom} added line(s) carry a byte-order mark")
+    if n_moji:
+        bits.append(f"{n_moji} added line(s) look like UTF-8 re-encoded as Latin-1")
+    return "; ".join(bits)
+
+
 def capture(tree, name, out_dir=PATCH_DIR):
     """Export a runtime tree's uncommitted changes as a tracked patch plus a manifest.
 
@@ -270,6 +289,17 @@ def capture(tree, name, out_dir=PATCH_DIR):
 
     added_archs = sorted({m for m in re.findall(r'^\+.*?"\s*([a-z][a-z0-9._\-]{2,31})\s*"',
                                                 diff, re.M)})
+    # Refuse to store encoding damage as if it were work. A byte-order mark, or text that was valid
+    # UTF-8 until an editor read it as Latin-1 and wrote it back, shows up as hunks that replace a
+    # line with a corrupted copy of itself. That is never an intended change, and once captured it
+    # becomes the thing you re-apply after a clone -- baking the damage in permanently.
+    # Found for real: 27 of 39 hunks in a k2-horizon capture were a BOM or mojibake, including inside
+    # a DeepSeek pre-tokenizer regex, which would mis-tokenize that model in any build made from it.
+    noise = encoding_noise(diff)
+    if noise:
+        return None, ("refusing to capture: this diff carries encoding damage, not just changes -- "
+                      + noise + ". Restore the affected files and re-apply only the hunks you meant, "
+                      "then capture again.")
     gi = git_info(tree)
     os.makedirs(out_dir, exist_ok=True)
     slug = _slug(tree)


### PR DESCRIPTION
…air and guard

Preparing the k2-horizon patch for an upstream PR showed it did not apply to ik_llama main, and splitting it apart showed why: 27 of its 39 hunks were not K2 work at all.

In src/llama-vocab.cpp, 2 of 16 hunks were the intended K2 additions. The other 14 were a byte-order mark and mojibake -- text that had been valid UTF-8 until an editor read it as Latin-1 and wrote it back. One of the damaged lines is the DeepSeek-LLM pre-tokenizer regex, 148 codepoints of Unicode ranges, so any build made from that tree tokenizes DeepSeek-LLM models wrong. In src/llama.cpp, 1 of 13 hunks was real: the `case LLM_ARCH_K2_HORIZON:` that selects NEOX rope. The rest was the same damage. Confirmed on the box at byte level, not inferred: the file carried a BOM and 15 mojibake byte sequences.

Repaired by restoring both files and re-applying only the hunks that name K2, after checking hunk by hunk that nothing intentional was in the rest. The tree now diffs as 198 insertions and ZERO deletions across 11 files -- a pure-addition patch, which is what adding an architecture should look like. Re-captured: the stored patch went from 32,905 bytes with deletions to 14,760 with none.

capture() now refuses a diff carrying that damage instead of storing it. This matters more than it sounds: a captured patch is what gets re-applied after a clone, so damage captured once is damage forever. It detects a BOM on an added line and the leading bytes of a Latin-1 round trip, and it is checked against both real damaged captures and against a legitimate non-ASCII addition -- a tokenizer regex full of real Unicode ranges must still capture clean.

All three patches verify APPLIED: 97/97, 135/135 and 50/50 added lines present.