### PR TITLE
pollard-bench: --coherence no longer swallows --speed

### DIFF
--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -767,6 +767,39 @@ def test_capture_refuses_encoding_damage():
     assert R.encoding_noise(legit) == "", R.encoding_noise(legit)
 
 
+def test_bench_coherence_does_not_swallow_speed():
+    """Asking pollard-bench for two measurements must not silently return one.
+
+    The coherence gate exited as soon as it had a verdict, which fired BEFORE the --speed branch. So
+    `--coherence --speed` printed a gate, exited 0, and produced no tok/s at all, with nothing saying
+    a requested measurement had been dropped. That is very likely why published cards have been
+    missing tok/s: the obvious command looks like it did everything.
+
+    Checked against the source rather than by running llama-cli, since the bug is purely one of
+    control flow -- the early exit must be conditional on nothing else having been asked for.
+    """
+    import re as _re
+
+    src = open(os.path.join(os.path.dirname(__file__), "..", "tools", "pollard_bench.py"),
+               encoding="utf-8").read()
+
+    # the gate's early exit must not fire when --speed was also requested
+    m = _re.search(r"gate_passed = print_gate\(res\)\s*\n\s*if ([^\n:]+):", src)
+    assert m, "the gate no longer stores its verdict before deciding to exit"
+    cond = m.group(1)
+    assert "a.speed" in cond, f"the gate still exits without considering --speed: {cond!r}"
+
+    # and the speed branch must come AFTER the gate, so both can run in one invocation
+    i_gate = src.index("gate_passed = print_gate(res)")
+    i_speed = src.index("=== decode speed ===")
+    assert i_gate < i_speed, "speed must run after the gate for both to be reachable"
+
+    # the speed-only exit must still report a gate verdict when a gate ran
+    tail = src[i_speed:i_speed + 2000]
+    assert "gate_passed is None" in tail, \
+        "the speed exit must distinguish 'no gate ran' from 'gate failed'"
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_bench.py
+++ b/tools/pollard_bench.py
@@ -264,6 +264,11 @@ def main():
     a = ap.parse_args()
 
     # --- coherence gate (can run standalone: no perplexity bin / eval corpus required) ---
+    # The gate used to exit here as soon as it had a verdict, which silently swallowed --speed: ask
+    # for both and you got the gate, exit 0, and no tok/s anywhere. A measuring tool must not drop a
+    # measurement you asked for without saying so, so the verdict is held and the exit happens after
+    # every requested measurement has run.
+    gate_passed = None
     if a.coherence or a.quick:
         if not os.path.exists(a.gguf):
             sys.exit(f"file not found: {a.gguf}")
@@ -271,9 +276,9 @@ def main():
         if not cli_bin:
             sys.exit("llama-cli not found — build llama.cpp/ik_llama.cpp or pass --llama-cli.")
         res = coherence_gate(cli_bin, a.gguf, a.ngl, quick=a.quick)
-        passed = print_gate(res)
-        if not a.ref:                      # gate-only invocation -> done (exit code reflects verdict)
-            sys.exit(0 if passed else 2)
+        gate_passed = print_gate(res)
+        if not a.ref and not a.speed:      # nothing else was asked for -> exit on the verdict
+            sys.exit(0 if gate_passed else 2)
 
     if a.speed:
         cli_bin = find_llama_bin(a.llama_cli)
@@ -292,7 +297,8 @@ def main():
                       + (f"  ({pro:.0f} prompt)" if pro else ""))
         print("  tok/s is hardware-specific -- name the machine wherever you publish it.")
         if not a.ref and not os.path.exists(a.eval):
-            sys.exit(0)                    # speed-only invocation: nothing to score, and that is fine
+            # nothing left to score. If a gate also ran, its verdict is what the exit code means.
+            sys.exit(0 if gate_passed is None else (0 if gate_passed else 2))
 
     ppl_bin = find_llama_bin(a.llama_perplexity)
     if not ppl_bin:


### PR DESCRIPTION
Asking for both measurements returned one, silently. The coherence gate exited as soon as it had a verdict, and that exit fired before the --speed branch, so `--coherence --speed` printed a gate, exited 0, and produced no tok/s anywhere. Nothing said a requested measurement had been dropped.

This is very likely why published cards have been missing tok/s. The obvious command looks like it did everything you asked, and the exit code agrees.

The gate now stores its verdict instead of exiting on it, and the early exit is conditional on nothing else having been requested. When a speed-only run finishes and a gate also ran, the exit code still reports the gate verdict rather than flattening it to 0.

Caught while rebuilding the Qwen2.5-7B rungs on stock atoms: the gate passed both and I had no speed numbers for the card. With the fix, the same command gives both in one run -- IQ4_XS 102.7 tok/s, IQ3_S 132.2 tok/s on the RTX 5070 Ti at full offload, alongside PASS on all three gate prompts.

The test asserts the control flow rather than running llama-cli, since the bug was purely ordering: the gate's exit must consider --speed, the speed branch must come after the gate, and the speed-only exit must still distinguish "no gate ran" from "gate failed". Verified it fails against the original condition and passes against the fix.