### PR TITLE
pollard-ggufcheck --backends: a backend can accept a file and still c…

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -31,7 +31,10 @@ Tools added since `v1.3.0` — **46 CLI tools** now:
   the tensor types (stock llama.cpp rejects any ggml type above 42) and `general.architecture`. Either
   alone can stop a file loading. It separates "your llama.cpp is older than this architecture" from
   "no upstream support exists", asking ggml-org master rather than trusting a snapshot, and says
-  nothing at all when it cannot check. Exits non-zero, so it works as a pre-publish gate.
+  nothing at all when it cannot check. `--backends` adds what a non-CUDA/Metal backend does with the
+  file: OpenVINO accepts no IQ type at all, and its NPU path requantizes Q6_K to Q4_0_128, discarding
+  a measured allocation while the load reports success. Exits non-zero, so it works as a pre-publish
+  gate.
 - `pollard-reclaim` — free the disk a finished model still holds, but only once the published copy is
   proven identical (matched by exact length, then confirmed head/middle/tail against the Hub). Reports
   by default; deleting is opt-in, and sources are a separate opt-in again.

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -800,6 +800,41 @@ def test_bench_coherence_does_not_swallow_speed():
         "the speed exit must distinguish 'no gate ran' from 'gate failed'"
 
 
+def test_backend_report_flags_rewrites_not_just_rejections():
+    """A backend that ACCEPTS a file can still change it, and that must be reported too.
+
+    OpenVINO's NPU path requantizes Q6_K to Q4_0_128. The load succeeds, the model runs, and the
+    measured allocation is gone -- the same failure shape as a fork-only atom or an unknown
+    architecture, which is the third time this pattern has cost us. And no IQ type is on OpenVINO's
+    accepted list at all, so most of what Pollard publishes cannot load there in any form.
+    """
+    import pollard_ggufcompat as gc
+
+    # an IQ ladder rung: unsupported everywhere on OpenVINO
+    iq = {0: 100, 23: 200, 21: 50}            # F32, IQ4_XS, IQ3_S
+    rep = gc.backend_report(iq)
+    for key in ("openvino-cpu", "openvino-gpu", "openvino-npu"):
+        verdict, detail = rep[key]
+        assert verdict == "unsupported", (key, verdict, detail)
+        assert "IQ4_XS" in detail, detail
+
+    # Q6_K: accepted everywhere, but rewritten -- and to something WORSE on NPU
+    q6 = {0: 100, 14: 200}                    # F32, Q6_K
+    rep2 = gc.backend_report(q6)
+    assert rep2["openvino-cpu"][0] == "rewritten", rep2["openvino-cpu"]
+    assert "Q8_0_C" in rep2["openvino-cpu"][1]
+    assert rep2["openvino-npu"][0] == "rewritten", rep2["openvino-npu"]
+    assert "Q4_0_128" in rep2["openvino-npu"][1], rep2["openvino-npu"][1]
+
+    # Q4_0 is the one scheme that survives untouched on every OpenVINO device
+    q4 = {0: 100, 2: 200}                     # F32, Q4_0
+    rep3 = gc.backend_report(q4)
+    assert all(v == "ok" for v, _ in rep3.values()), rep3
+
+    # F32 alone must never be called a quantization problem
+    assert all(v == "ok" for v, _ in gc.backend_report({0: 10}).values())
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_ggufcompat.py
+++ b/tools/pollard_ggufcompat.py
@@ -157,6 +157,61 @@ IK_NAMES = {133: "Q6_0", 134: "IQ1_BN", 135: "IQ2_BN", 136: "Q8_K64", 137: "IQ2_
             157: "IQ2_KL", 158: "IQ1_KT"}
 
 
+# What a non-CUDA/Metal BACKEND will accept, and what it silently does to the rest.
+#
+# "Which runtime opens this file" is only half the question. A backend can open a file and then change
+# it: OpenVINO's NPU path requantizes Q6_K to Q4_0_128, which discards a measured allocation while
+# reporting success. That is the same failure shape as a fork-only atom -- the file works, and is not
+# what the card promised.
+#
+# Source: llama.cpp docs/backend/OPENVINO.md. `accepts` is the documented scheme list; `rewrites` maps
+# an accepted type to what the backend turns it into on that device.
+BACKENDS = {
+    "openvino-cpu": {
+        "label": "OpenVINO (Intel CPU)",
+        "accepts": {"F16", "BF16", "Q8_0", "Q4_0", "Q4_1", "Q4_K", "Q5_K", "Q6_K"},
+        "rewrites": {"Q5_K": "Q8_0_C", "Q6_K": "Q8_0_C"},
+        "note": "BF16 is Xeon-only",
+    },
+    "openvino-gpu": {
+        "label": "OpenVINO (Intel GPU)",
+        "accepts": {"F16", "Q8_0", "Q4_0", "Q4_1", "Q4_K", "Q5_K", "Q6_K"},
+        "rewrites": {"Q5_K": "Q8_0_C", "Q6_K": "Q8_0_C"},
+        "note": "",
+    },
+    "openvino-npu": {
+        "label": "OpenVINO (Intel NPU)",
+        "accepts": {"F16", "Q8_0", "Q4_0", "Q4_1", "Q4_K", "Q5_K", "Q6_K"},
+        "rewrites": {"Q6_K": "Q4_0_128", "Q5_K": "Q4_0_128"},
+        "note": "Q4_0 is the primary scheme; embedding Q6_K goes to Q8_0_C and the token embedding "
+                "is dequantized to fp16",
+    },
+}
+
+
+def backend_report(counts):
+    """{backend key: (verdict, detail)} for a tensor-type histogram.
+
+    verdict is 'ok' (every type accepted and kept as-is), 'rewritten' (accepted but the backend
+    changes some tensors) or 'unsupported' (a type the backend does not take at all).
+    """
+    out = {}
+    present = {type_name(t) for t in counts}
+    for key, spec in BACKENDS.items():
+        # F32 is always fine: it is the accumulate/norm type, not a quantization scheme
+        quant = {n for n in present if n != "F32"}
+        missing = sorted(n for n in quant if n not in spec["accepts"])
+        if missing:
+            out[key] = ("unsupported", f"does not accept {', '.join(missing)}")
+            continue
+        changed = sorted(f"{n} -> {spec['rewrites'][n]}" for n in quant if n in spec["rewrites"])
+        if changed:
+            out[key] = ("rewritten", "; ".join(changed))
+        else:
+            out[key] = ("ok", "")
+    return out
+
+
 def type_name(t):
     return STOCK_NAMES.get(t) or IK_NAMES.get(t) or f"type{t}"
 
@@ -323,6 +378,10 @@ def main():
     ap.add_argument("files", nargs="*", help="GGUF paths (or URLs)")
     ap.add_argument("--repo", help="check every .gguf in a published HF repo instead")
     ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--backends", action="store_true",
+                    help="also report what non-CUDA/Metal backends do with this file. A backend can "
+                         "ACCEPT a file and still change it -- OpenVINO's NPU path requantizes Q6_K "
+                         "to Q4_0_128, which discards a measured allocation while reporting success")
     ap.add_argument("--offline", action="store_true",
                     help="do not ask upstream what it implements. An architecture missing from the "
                          "local list then reports as unverified instead of being called fork-only -- "
@@ -352,7 +411,13 @@ def main():
             if not a.json:
                 print(f"  UNREADABLE  {name}\n              {e}")
             continue
-        rows.append({"file": name, "runtime": rt, "reasons": fo})
+        row = {"file": name, "runtime": rt, "reasons": fo}
+        if a.backends:
+            try:
+                row["backends"] = backend_report(read_header(t)[1])
+            except Exception:                                              # noqa: BLE001
+                row["backends"] = {}
+        rows.append(row)
         if rt != "stock":
             rc = 1                     # 'newer' counts: the runtime here still cannot open it
         if not a.json:
@@ -375,6 +440,11 @@ def main():
             else:
                 label, why = "stock llama.cpp", ""
             print(f"  {label:<16}  {name}{why}")
+            for key, (verdict, detail) in (row.get("backends") or {}).items():
+                mark = {"ok": "loads as built", "rewritten": "REWRITTEN",
+                        "unsupported": "UNSUPPORTED"}[verdict]
+                line = f"      {BACKENDS[key]['label']:<24} {mark}"
+                print(line + (f"  ({detail})" if detail else ""))
 
     if a.json:
         print(json.dumps(rows, indent=1))


### PR DESCRIPTION
…hange it

Third instance of the same failure shape tonight. A fork-only atom stops a file loading; an unknown architecture stops it loading; and a backend can LOAD it and quietly rewrite it. All three are answerable from the header, and all three otherwise surface as "the card says this runs here and it does not behave".

From llama.cpp docs/backend/OPENVINO.md, the accepted schemes are FP16, BF16 (Xeon only), Q8_0, Q4_0, Q4_1, Q4_K, Q4_K_M, Q5_K and Q6_K. No IQ type is on that list. Every ladder Pollard publishes is built on the IQ family, so on Intel's OpenVINO path none of it loads at all. Checked against a real published repo: four of FrogMini-14B's five rungs come back UNSUPPORTED on CPU, GPU and NPU alike.

Where a type IS accepted it may still be altered. CPU and GPU convert Q5_K and Q6_K to Q8_0_C. The NPU requantizes Q6_K to Q4_0_128 -- the near-lossless rung dropped to four bits, the measured allocation gone, and the load reporting success the whole way. Q4_0 is the only scheme that survives untouched on every OpenVINO device.

--backends reports ok / REWRITTEN / UNSUPPORTED per device with the specific rewrite named. F32 never counts as a quantization problem, since it is the accumulate and norm type rather than a scheme.

The registry is data with a cited source, so adding Hexagon or another backend is a table entry rather than new logic. Hexagon is deliberately absent for now: its llama.cpp backend is still a WIP draft and quantized matmul falls back to CPU, so there is nothing stable to encode.