### PR TITLE
pollard-calc: count KV on the layers that produce it, and the indexer…

### DIFF
--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -835,6 +835,52 @@ def test_backend_report_flags_rewrites_not_just_rejections():
     assert all(v == "ok" for v, _ in gc.backend_report({0: 10}).values())
 
 
+def test_kv_counts_only_the_layers_that_produce_it():
+    """KV must be counted on the layers that PRODUCE it, and the indexer cache on every arch.
+
+    DeepSeek-V4.1-Flash runs CSA2: most layers read a previous layer's KV and keep none of their own.
+    Its config says which produce it -- kv_source_layer_ids = [2, 8, 14, 20], four of forty layers.
+    Counting all forty overstates the cache by 10x, and at a 1M context that is the number deciding
+    whether the model fits a box at all.
+
+    The second bug was worse because it was silent: the indexer cache was added only on the MLA
+    branch. This model has no kv_lora_rank, so its 8 indexer layers vanished and the estimate halved.
+
+    Validated against a served measurement: 12 GiB pinned holding 2.56 M tokens with fp4 KV
+    = 4.92 KB/token. The model lands at 4.00, 19 % under -- the right order, where it had been 2.5x
+    out before.
+    """
+    import pollard_calc as pc
+
+    cfg = {
+        "num_hidden_layers": 40,
+        "kv_source_layer_ids": [2, 8, 14, 20],
+        "index_source_layer_ids": [2, 8, 14, 20, 24, 28, 32, 36],
+        "index_head_dim": 128,
+        "num_key_value_heads": 1,
+        "head_dim": 512,
+        "hidden_size": 5120,
+        "num_attention_heads": 64,
+    }
+    a = pc.analyse(cfg)
+    assert a["layers"] == 40
+    assert a["n_kv_layers"] == 4, a.get("n_kv_layers")
+    assert a["n_indexer"] == 8, a.get("n_indexer")
+
+    kb = pc.kv_cache_bytes(a, 1_000_000, 0.5) / 1_000_000 / 1024
+    assert 3.5 < kb < 6.0, f"{kb} KB/token is not near the measured 4.92"
+
+    # counting all 40 layers -- the old behaviour -- must be far away from measured
+    naive = dict(a); naive["n_kv_layers"] = 0; naive["n_full"] = 0
+    kb_naive = pc.kv_cache_bytes(naive, 1_000_000, 0.5) / 1_000_000 / 1024
+    assert kb_naive > 2 * kb, f"all-layer count {kb_naive} should dwarf {kb}"
+
+    # and the indexer must be counted even with no MLA latent present
+    no_idx = dict(a); no_idx["index_head_dim"] = 0
+    assert pc.kv_cache_bytes(no_idx, 1_000_000, 0.5) < pc.kv_cache_bytes(a, 1_000_000, 0.5), \
+        "the indexer cache must add bytes on a non-MLA architecture"
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_calc.py
+++ b/tools/pollard_calc.py
@@ -384,8 +384,23 @@ def analyse(cfg):
     # indexer_types == "shared" (Hy4: 57 of 78) reuse a previous layer's top-k and keep no cache of their own.
     index_head_dim = first(cfg, "index_head_dim", default=0) or 0
     idx_types = cfg.get("indexer_types")
-    n_indexer = (sum(1 for t in idx_types if str(t) != "shared") if isinstance(idx_types, list)
-                 else (layers if index_head_dim else 0))
+    # Newer sparse-attention stacks name the producing layers OUTRIGHT instead of tagging each layer.
+    # DeepSeek-V4.1-Flash: index_source_layer_ids = [2, 8, 14, 20, 24, 28, 32, 36], so 8 of 40 layers
+    # run an indexer and the rest reuse one.
+    idx_src = first(cfg, "index_source_layer_ids")
+    if isinstance(idx_src, list) and idx_src:
+        n_indexer = len(idx_src)
+    else:
+        n_indexer = (sum(1 for t in idx_types if str(t) != "shared") if isinstance(idx_types, list)
+                     else (layers if index_head_dim else 0))
+
+    # Layers that actually PRODUCE a KV cache. CSA2 (DeepSeek-V4.1-Flash) runs most layers in Reuse
+    # mode: they read a previous layer's KV and keep none of their own. The config says which produce
+    # it -- kv_source_layer_ids = [2, 8, 14, 20] means FOUR of forty layers hold KV, not forty.
+    # Counting every layer overstates the cache by 10x on that model, and KV is exactly the number
+    # that decides whether it fits a given box at its 1M context.
+    kv_src = first(cfg, "kv_source_layer_ids")
+    n_kv_layers = len(kv_src) if isinstance(kv_src, list) and kv_src else 0
 
     n_experts = first(cfg, "num_experts", "n_routed_experts",
                       "num_local_experts", "moe_num_experts")
@@ -459,7 +474,7 @@ def analyse(cfg):
         "attn_params": attn,                      # per-layer attention (q,k,v,o) — its own group
         "dense_layers": dense_layers,
         "multimodal": multimodal, "hybrid": hybrid,
-        "n_linear": n_linear, "n_full": n_full, "mtp": mtp,
+        "n_linear": n_linear, "n_full": n_full, "mtp": mtp, "n_kv_layers": n_kv_layers,
         "kv_heads": kv_heads, "head_dim": head_dim,
         "mla": kv_lora_rank > 0, "kv_lora_rank": kv_lora_rank,
         "qk_rope_head_dim": qk_rope_head_dim,
@@ -471,7 +486,9 @@ def kv_cache_bytes(a, ctx, kv_bytes=2.0):
     """KV-cache bytes at `ctx` tokens. Arch-aware: MLA (DeepSeek/GLM) stores one
     compressed latent per token/layer (tiny); hybrid models only grow KV on their
     full-attention layers. kv_bytes: 2 = f16 cache (default), 1 = q8_0, ~0.56 = q4."""
-    n_attn = a.get("n_full") or a["layers"]                 # linear layers barely grow KV
+    # KV-producing layers, most specific first: an explicit kv_source_layer_ids list (CSA2 Reuse),
+    # then a hybrid model's full-attention layers, then every layer.
+    n_attn = a.get("n_kv_layers") or a.get("n_full") or a["layers"]
     # DSA indexer key cache: index_head_dim per token on every layer that runs its own indexer. Not compressed by the
     # NVFP4 latent path (bf16 keys), fp8/f16 otherwise — GLM-5.3 measured: 41 KB/tok nvfp4, 57 KB fp8 (latent-only
     # model: 22 / 45 KB). Anything below 1 byte/elem for the latent still costs ~2 bytes/elem here.
@@ -482,7 +499,10 @@ def kv_cache_bytes(a, ctx, kv_bytes=2.0):
         per_tok_layer = a["kv_lora_rank"] + (a.get("qk_rope_head_dim") or 0)
         return n_attn * ctx * per_tok_layer * kv_bytes + idx   # MLA: single latent, no K/V split (+ indexer cache)
     kvh, hd = a.get("kv_heads") or 0, a.get("head_dim") or 0
-    return 2 * n_attn * ctx * kvh * hd * kv_bytes           # GQA/MHA: K and V
+    # `+ idx` is not optional here. The indexer cache used to be added only on the MLA branch, so a
+    # sparse-attention model that is NOT MLA lost it silently -- DeepSeek-V4.1-Flash has no
+    # kv_lora_rank but does run 8 indexer layers, and dropping them halved its KV estimate.
+    return 2 * n_attn * ctx * kvh * hd * kv_bytes + idx     # GQA/MHA: K and V (+ indexer cache)
 
 
 # per-card VRAM (GB) for the --gpu convenience; anything not listed, pass GB directly


### PR DESCRIPTION
… everywhere

Two bugs, found by running pollard-calc against DeepSeek-V4.1-Flash's real config rather than reasoning about the architecture diagram.

1. CSA2 Reuse layers were counted as holding KV. Most of that model's layers read a previous layer's KV and keep none of their own; the config names the producers outright, kv_source_layer_ids = [2, 8, 14, 20]. Four of forty. Counting all forty overstates the cache by 10x, and at its 1M context that is precisely the number that decides whether the model fits a box. index_source_layer_ids is read the same way (8 of 40 run an indexer), alongside the older indexer_types form.

2. The indexer key cache was added ONLY on the MLA branch. This model has no kv_lora_rank, so it takes the GQA path and its 8 indexer layers were dropped in silence -- halving the estimate on a model where the indexer is about as large as the KV itself.

Validated against a served measurement rather than a derivation: bot-lab-21 report 12 GiB pinned holding 2.56 M tokens with native fp4 KV, which is 4.92 KB/token. Before, this model computed 2.00 KB/token, 2.5x out. Now 4.00, 19 % under -- the right order, with the remainder plausibly the candidate pool and DSpark overheads the config does not expose.

Worth stating plainly: neither bug was visible from the architecture figure. The diagram shows CSA2(1, Reuse) blocks, but it took loading the config to learn that only four layers source KV, and it took checking a measured number to notice the indexer was missing from an entire code path.