### PR TITLE
pollard-archfp: surface the per-layer structure a tensor layout canno…

### DIFF
--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -881,6 +881,50 @@ def test_kv_counts_only_the_layers_that_produce_it():
         "the indexer cache must add bytes on a non-MLA architecture"
 
 
+def test_archfp_surfaces_per_layer_structure_a_twin_would_miss():
+    """A layout can score as a known twin while the config says it behaves nothing like one.
+
+    DeepSeek-V4.1-Flash's tensor names fingerprint as an ordinary MLA MoE. What makes it different
+    lives in LIST-valued hparams the numeric gap check could not see: kv_source_layer_ids says only
+    4 of its 40 layers produce KV at all. A twin that ignores that overstates the cache tenfold, on a
+    model whose 1M context makes KV the number that decides whether it fits anything.
+    """
+    import pollard_archfp as A
+
+    names = ["token_embd.weight", "output.weight", "output_norm.weight"]
+    for i in range(4):
+        for t in ("attn_q_a", "attn_q_b", "attn_kv_a", "attn_kv_b", "attn_out", "attn_norm",
+                  "ffn_norm", "ffn_gate_inp", "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"):
+            names.append(f"blk.{i}.{t}.weight")
+    fp = A.fingerprint(names)
+
+    hp = {
+        "num_hidden_layers": 40,
+        "kv_source_layer_ids": [2, 8, 14, 20],
+        "index_source_layer_ids": [2, 8, 14, 20, 24, 28, 32, 36],
+        "engram_layer_ids": [1, 14],
+        "compress_ratios": [0, 0] + [2] * 38,
+        "hc_mult": 4,
+    }
+    res = A.twin(fp, hp)
+    what = " | ".join(g["what"] for g in res["gaps"])
+
+    assert not res["exact"], "a model with per-layer KV sourcing must never read as an exact twin"
+    assert "kv_source_layer_ids" in what, what
+    assert "4 of 40 layers" in what, what          # the count, not just the key name
+    assert "index_source_layer_ids" in what, what
+    assert "engram_layer_ids" in what, what
+    assert "hc_mult" in what, what
+
+    # every gap must say what supporting it would take, not merely refuse
+    for g in res["gaps"]:
+        assert g.get("to_support"), g
+
+    # an ordinary model must not collect these gaps
+    plain = A.twin(fp, {"num_hidden_layers": 40})
+    assert "kv_source_layer_ids" not in " ".join(g["what"] for g in plain["gaps"])
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_archfp.py
+++ b/tools/pollard_archfp.py
@@ -187,6 +187,10 @@ def twin(fp, hparams=None):
          "attention-side expert routing: per-layer attn_v_gate + attn_v_exps, selected by "
          "n_value_expert/n_value_expert_used. No current family models it -- extend the dense "
          "builder with a gated value path, then add it here as its own family"),
+        ("hc_mult", "hyper-connections: the residual is several parallel streams",
+         "activation memory and any band/layer hand-off scale by this factor, and each block's "
+         "output reaches the residual through a learned gain -- an allocator that weights tensors by "
+         "their own error alone will send bits to layers whose output barely arrives"),
         ("expert_count", "experts",
          "route the FFN through the expert tensors and the router (an MoE family already covers "
          "the common shapes)"),
@@ -197,6 +201,33 @@ def twin(fp, hparams=None):
             seen.add(k)                    # a key matches the most specific rule only
             gaps.append({"what": f"{label}: {k}={v} -- a plain twin would silently mis-build this",
                          "to_support": how})
+    # LIST-valued hparams name a per-layer structure the numeric loop above cannot see, and they are
+    # where the newest architectures keep the facts that change an allocation. DeepSeek-V4.1-Flash is
+    # the case that forced this: its tensor layout scores as an ordinary MoE twin, while
+    # kv_source_layer_ids says only 4 of its 40 layers hold KV at all. A twin that ignores that
+    # overstates the cache tenfold on a model whose 1M context makes KV the deciding number.
+    for key, label, how in (
+        ("kv_source_layer_ids", "only some layers PRODUCE KV (CSA2 Reuse and friends)",
+         "read the list and size the KV cache on its length, not the layer count -- pollard-calc "
+         "does this; any allocator reasoning about cache bytes must too"),
+        ("index_source_layer_ids", "only some layers run a sparse-attention indexer",
+         "count the indexer key cache on these layers alone; the rest reuse a previous layer's top-k"),
+        ("engram_layer_ids", "n-gram lookup tables sit at specific layers",
+         "these are lookup rows, not weights: they are not quantized by a bits-per-weight budget and "
+         "belong in a residency/frequency ledger instead"),
+        ("compress_ratios", "per-layer attention compression ratio",
+         "attention cost and cache differ per layer; a single per-model attention shape is wrong here"),
+    ):
+        for k, v in hparams.items():
+            if k in seen or not k.endswith(key) or not isinstance(v, (list, tuple)) or not v:
+                continue
+            seen.add(k)
+            n_layers = hparams.get("num_hidden_layers") or fp.get("n_blocks") or 0
+            detail = f"{k}={list(v)[:8]}{'...' if len(v) > 8 else ''}"
+            if key.endswith("layer_ids") and n_layers:
+                detail += f" -- {len(v)} of {n_layers} layers"
+            gaps.append({"what": f"{label}: {detail}", "to_support": how})
+
     if fp["unknown"]:
         names = ", ".join(sorted(fp["unknown"])[:6])
         gaps.append({"what": "per-block tensors no family accounts for: " + names,


### PR DESCRIPTION
…t show

DeepSeek-V4.1-Flash fingerprints as an ordinary deepseek-mla-moe twin. That is the trap: the tensor names look familiar and the differences that matter are not in them. They are in list-valued hparams the gap check could not see, because it only accepted ints and floats.

kv_source_layer_ids = [2, 8, 14, 20]. Four of forty layers produce KV; the rest run CSA2 in Reuse mode and keep none. A twin that assumes forty overstates the cache tenfold, on a model whose 1M context makes KV the number that decides whether it fits a box at all. pollard-calc now reads that list; archfp now says out loud that it must be read.

Four more join it: index_source_layer_ids (8 of 40 run an indexer, the rest reuse a top-k), engram_layer_ids (lookup rows, not weights -- a bits-per-weight budget does not apply and they belong in a residency ledger), compress_ratios (attention shape differs per layer, so one per-model shape is wrong), and hc_mult (the residual is four parallel streams, so activation memory scales by it and each block reaches the residual through a learned gain -- weighting tensors by their own error alone sends bits to layers whose output barely arrives).

Each gap says what supporting it would take rather than refusing, which is the existing contract, and the test asserts that as well as the specific counts. An ordinary model collects none of them.