### PR TITLE
pollard-bench: read the classic timing block, so trellis builds repor…

### DIFF
--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -925,6 +925,37 @@ def test_archfp_surfaces_per_layer_structure_a_twin_would_miss():
     assert "kv_source_layer_ids" not in " ".join(g["what"] for g in plain["gaps"])
 
 
+def test_speed_parser_reads_the_classic_timing_block():
+    """Decode speed must parse on ik_llama too, not only on builds that print "Generation: t/s".
+
+    pollard-bench matched one format. ik_llama and older llama.cpp print the classic timing block
+    instead, so every trellis build came back "no speed line" -- which is why no IQ*_KT rung has ever
+    carried a tok/s figure on a card. Measuring the wrong thing is bad; silently measuring nothing and
+    reporting success is worse.
+    """
+    import pollard_bench as pb
+
+    classic = (
+        "main: prompt eval time =     217.23 ms /     1 tokens (  217.23 ms per token,"
+        "     4.60 tokens per second)\n"
+        "main:        eval time =     156.00 ms /    32 tokens (    4.88 ms per token,"
+        "   205.12 tokens per second)\n"
+        "main:       total time =     400.00 ms\n"
+    )
+    gen, pro = pb._classic_speeds(classic)
+    assert gen == 205.12, gen          # generation is the plain "eval time" line
+    assert pro == 4.60, pro            # prompt is the "prompt eval time" line
+
+    # the two lines must not be confused: prompt is far slower here, so a mix-up is obvious
+    assert gen > pro
+
+    # a build that prints neither format yields nothing rather than a wrong number
+    assert pb._classic_speeds("main: total time = 400.00 ms\n") == (None, None)
+
+    # lines mentioning tokens per second that are NOT timing lines are ignored
+    assert pb._classic_speeds("note: we measured 999.0 tokens per second once\n") == (None, None)
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_bench.py
+++ b/tools/pollard_bench.py
@@ -211,6 +211,28 @@ def _fmt(v, nd=4):
 
 _SPEED = re.compile(r"Generation:\s*([\d.]+)\s*t/s")
 _PROMPT_SPEED = re.compile(r"Prompt:\s*([\d.]+)\s*t/s")
+# ik_llama and older llama.cpp print the classic timing block instead:
+#   main: prompt eval time = 217.23 ms / 1 tokens ( 217.23 ms per token, 4.60 tokens per second)
+#   main:        eval time = 156.00 ms / 32 tokens (   4.88 ms per token, 205.12 tokens per second)
+# Matching only "Generation: t/s" meant every trellis build reported "no speed line", which is why
+# IQ*_KT rungs have never carried a tok/s figure on a card.
+_CLASSIC = re.compile(r"([\d.]+)\s*tokens per second")
+
+
+def _classic_speeds(text):
+    """(generation, prompt) from the classic timing block, either may be None."""
+    gen = pro = None
+    for line in text.splitlines():
+        if "tokens per second" not in line or "eval time" not in line:
+            continue
+        m = _CLASSIC.search(line)
+        if not m:
+            continue
+        if "prompt eval time" in line:
+            pro = float(m.group(1))
+        else:
+            gen = float(m.group(1))
+    return gen, pro
 
 
 def measure_speed(cli_bin, model, ngl, n_predict=128,
@@ -237,7 +259,12 @@ def measure_speed(cli_bin, model, ngl, n_predict=128,
         return None, None
     out = (r.stdout or "") + (r.stderr or "")
     g, p = _SPEED.search(out), _PROMPT_SPEED.search(out)
-    return (float(g.group(1)) if g else None), (float(p.group(1)) if p else None)
+    gen = float(g.group(1)) if g else None
+    pro = float(p.group(1)) if p else None
+    if gen is None:                        # older/ik_llama builds print the classic timing block
+        gen, pro2 = _classic_speeds(out)
+        pro = pro if pro is not None else pro2
+    return gen, pro
 
 
 def main():


### PR DESCRIPTION
…t speed

measure_speed() matched only "Generation: X t/s". ik_llama and older llama.cpp print the classic block instead:

  main: prompt eval time =  217.23 ms /  1 tokens (217.23 ms per token,   4.60 tokens per second)
  main:        eval time =  156.00 ms / 32 tokens (  4.88 ms per token, 205.12 tokens per second)

So every IQ*_KT rung came back "no speed line". That is why no trellis rung has ever carried a tok/s figure on a card -- the measurement was never possible, and nothing said so beyond one easily-missed line.

Caught measuring the published Qwen2.5 rungs to fill in their cards: both IQ1_KT files reported no speed while their perplexity measured fine, which is the tell that it was the parser and not the model.

The fallback runs only when the primary pattern misses, reads generation from the plain "eval time" line and prompt from "prompt eval time", and returns nothing rather than a wrong number when neither format is present. The test pins the two lines apart, since confusing them would report prompt speed as decode speed -- 4.60 against 205.12 here.

Second speed bug in two days, after --coherence silently swallowing --speed. Both had the same shape: the tool reported success while producing no measurement.