### PR TITLE
Fix/card grammar and punctuation

### DIFF
--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -993,6 +993,40 @@ def test_card_calib_note_is_not_double_punctuated():
     assert 'not in ".!?"' in src, "no guard against double punctuation in the calibration note"
 
 
+def test_card_attribution_follows_the_publisher_not_the_tool():
+    """A cloned Pollard must not credit PollardWeights for someone else's build.
+
+    `quantized_by: PollardWeights` was hardcoded into the frontmatter and the repo id defaulted to a
+    PollardWeights repo, so anyone else running pollard-card produced a card that credited us and
+    pointed every download line at our repos. No credential ever leaked -- huggingface_hub resolves
+    the token from the caller's own login -- but the attribution followed the tool, not the publisher.
+    """
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+    import pollard_card as C
+
+    here = os.path.dirname(__file__)
+    src = open(os.path.join(here, "..", "tools", "pollard_card.py"), encoding="utf-8").read()
+    assert '"quantized_by: PollardWeights"' not in src, "frontmatter still hardcodes our account"
+    assert 'a.repo or f"PollardWeights/' not in src, "repo id still defaults to our account"
+
+    # resolution order: explicit flag, then the repo being written/uploaded to
+    assert C.publishing_account("acme") == "acme"
+    assert C.publishing_account(None, "someone/Model-Pollard") == "someone"
+    assert C.publishing_account(None, None, "other/Model-Pollard") == "other"
+    # an explicit flag outranks the repo owner
+    assert C.publishing_account("acme", "someone/Model-Pollard") == "acme"
+
+    # with nobody identified the line is omitted rather than filled with a wrong or fake name
+    anon = C.frontmatter("Qwen/Qwen2.5-7B-Instruct", "apache-2.0", ["gguf"], "qwen2", None)
+    assert "quantized_by" not in anon, "unattributed card invented an owner"
+    named = C.frontmatter("Qwen/Qwen2.5-7B-Instruct", "apache-2.0", ["gguf"], "qwen2", "acme")
+    assert "quantized_by: acme" in named
+
+    # and reclaim no longer checks everyone's local builds against our repos
+    rsrc = open(os.path.join(here, "..", "tools", "pollard_reclaim.py"), encoding="utf-8").read()
+    assert 'default="PollardWeights"' not in rsrc, "reclaim still defaults --owner to our account"
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -956,6 +956,28 @@ def test_speed_parser_reads_the_classic_timing_block():
     assert pb._classic_speeds("note: we measured 999.0 tokens per second once\n") == (None, None)
 
 
+def test_card_rung_list_agrees_in_number():
+    """One fork-only rung must not be described in the plural.
+
+    The stock rebuild of both Qwen repos left exactly one trellis rung, and the card then read
+    "`IQ1_KT` need ik_llama.cpp: their allocation puts ..." -- grammatically wrong in the one
+    sentence a reader uses to decide whether the file will open on their machine.
+    """
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+    import pollard_card as C
+
+    assert C.rung_agreement(1) == ("needs", "carries", "its")
+    assert C.rung_agreement(2) == ("need", "carry", "their")
+    assert C.rung_agreement(4) == ("need", "carry", "their")
+
+    # and the template must actually use it -- checked on the rendered sentence rather than by
+    # grepping the source, which trips over the helper's own docstring.
+    src = open(os.path.join(os.path.dirname(__file__), "..", "tools", "pollard_card.py"),
+               encoding="utf-8").read()
+    for frag in ("{need} {v_need} [ik_llama.cpp]", "{names} {v_carry} ik_llama-only atoms"):
+        assert frag in src, f"rung list still not agreement-aware: {frag}"
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -978,6 +978,21 @@ def test_card_rung_list_agrees_in_number():
         assert frag in src, f"rung list still not agreement-aware: {frag}"
 
 
+def test_card_calib_note_is_not_double_punctuated():
+    """A calibration note that ends in a period must not get a second one appended.
+
+    The Qwen cards' calib note ends with a sentence about test-set disjointness -- exactly the claim a
+    reader checks hardest -- and it rendered as "tuned on..".
+    """
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+    import pollard_card as C
+
+    src = open(os.path.join(os.path.dirname(__file__), "..", "tools", "pollard_card.py"),
+               encoding="utf-8").read()
+    assert '+ "."' not in src, "calibration note still appends a period unconditionally"
+    assert 'not in ".!?"' in src, "no guard against double punctuation in the calibration note"
+
+
 def main():
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     fails = 0

--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -154,6 +154,16 @@ def load_builds(key, lane=None):
     return [b for b in builds if (not lane or b.get("lane") == lane)]
 
 
+def rung_agreement(n):
+    """Verb and pronoun agreement for a list of rungs, so a single fork-only rung is not plural.
+
+    With one rung needing ik_llama the card read "`IQ1_KT` need ik_llama.cpp: their allocation puts
+    ...", which is the one sentence on a measured-results card that announces nobody read it. Both
+    Qwen repos hit it the moment the stock rebuild left exactly one trellis rung.
+    """
+    return ("needs", "carries", "its") if n == 1 else ("need", "carry", "their")
+
+
 def human_gb(nbytes):
     return f"{nbytes/1e9:.2f} GB" if nbytes else "—"
 
@@ -325,9 +335,11 @@ def main():
         else:
             need = ", ".join(f"`{b.get('tag') or b.get('name')}`" for b in
                              sorted(ik_builds, key=lambda x: -(x.get("bytes") or 0)))
+            v_need, _, pron = rung_agreement(len(ik_builds))
             out += ["**Standard GGUF — runs in stock llama.cpp / ik_llama.cpp, Ollama, LM Studio, "
-                    f"except where noted.** {need} need [ik_llama.cpp]({IK_URL}): their allocation "
-                    "puts ik_llama-only atoms on the tensors it protects. The rest run anywhere.", ""]
+                    f"except where noted.** {need} {v_need} [ik_llama.cpp]({IK_URL}): {pron} "
+                    "allocation puts ik_llama-only atoms on the tensors it protects. The rest run "
+                    "anywhere.", ""]
 
     # ---- Model details: the at-a-glance table every good Pollard card opens with
     arch = a.arch or mtype or "—"
@@ -530,7 +542,8 @@ def main():
         elif ik_builds:
             names = ", ".join(f"`{b.get('tag') or b.get('name')}`" for b in
                               sorted(ik_builds, key=lambda x: -(x.get("bytes") or 0)))
-            out.append(f"- {names} carry ik_llama-only atoms and need ik_llama.cpp to run; "
+            v_need, v_carry, _ = rung_agreement(len(ik_builds))
+            out.append(f"- {names} {v_carry} ik_llama-only atoms and {v_need} ik_llama.cpp to run; "
                        "stock llama.cpp rejects any ggml type above 42 outright. Checked with "
                        "`pollard-ggufcheck`, from the files' tensor types rather than their names.")
         elif runtimes:

--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -509,10 +509,15 @@ def main():
 
     # ---- imatrix / calibration: what the allocation was measured on
     if a.imatrix_file:
+        # A note detailed enough to be worth reading ends in its own punctuation; appending a period
+        # unconditionally gave the Qwen cards "...the allocation was tuned on.." on the one line whose
+        # job is to make the measurement credible.
+        note = (a.calib_note or
+                "a mixed-domain corpus so the matrix sees every register the model serves").rstrip()
+        if note[-1:] not in ".!?":
+            note += "."
         out += ["## imatrix (calibration)", "",
-                f"The importance matrix (`{a.imatrix_file}`, included) was computed on "
-                + (a.calib_note or "a mixed-domain corpus so the matrix sees every register the model serves")
-                + ".", ""]
+                f"The importance matrix (`{a.imatrix_file}`, included) was computed on {note}", ""]
         if a.calib_file:
             out += [f"The exact corpus is included as `{a.calib_file}`, so the allocation can be "
                     "reproduced rather than taken on trust.", ""]

--- a/tools/pollard_card.py
+++ b/tools/pollard_card.py
@@ -154,12 +154,41 @@ def load_builds(key, lane=None):
     return [b for b in builds if (not lane or b.get("lane") == lane)]
 
 
+PLACEHOLDER_OWNER = "YOUR_HF_ACCOUNT"
+
+
+def publishing_account(explicit=None, repo=None, upload=None):
+    """Whose name goes on this card.
+
+    The template used to hardcode `quantized_by: PollardWeights` and default every download and usage
+    line to a PollardWeights repo id. That is fine while we are the only ones running it and wrong the
+    moment anyone else clones Pollard: their card credits us for their work and points readers at our
+    repos instead of theirs. No credential leaks either way -- huggingface_hub resolves the token from
+    the caller's own login -- but the attribution followed the tool instead of the publisher.
+
+    Resolution order, first hit wins: an explicit --quantized-by, the owner segment of the repo id
+    being written to or uploaded to, then whoever is logged in locally. None of those is a guess.
+    """
+    if explicit:
+        return explicit
+    for rid in (repo, upload):
+        if rid and "/" in rid:
+            owner = rid.split("/", 1)[0].strip()
+            if owner:
+                return owner
+    try:
+        from huggingface_hub import HfApi
+        return (HfApi().whoami() or {}).get("name") or None
+    except Exception:
+        return None
+
+
 def rung_agreement(n):
     """Verb and pronoun agreement for a list of rungs, so a single fork-only rung is not plural.
 
-    With one rung needing ik_llama the card read "`IQ1_KT` need ik_llama.cpp: their allocation puts
-    ...", which is the one sentence on a measured-results card that announces nobody read it. Both
-    Qwen repos hit it the moment the stock rebuild left exactly one trellis rung.
+    With one rung needing ik_llama the card used to read "`IQ1_KT` need ik_llama.cpp: their
+    allocation puts ...", which is the one sentence on a measured-results card that announces nobody
+    read it. Both Qwen repos hit it the moment the stock rebuild left exactly one trellis rung.
     """
     return ("needs", "carries", "its") if n == 1 else ("need", "carry", "their")
 
@@ -180,7 +209,7 @@ def parse_params_b(params, cfg):
     return round((12 * L * h * h + 2 * v * h) / 1e9, 2) if h and L else 0.0
 
 
-def frontmatter(base_model, lic, lanes, model_type):
+def frontmatter(base_model, lic, lanes, model_type, quantized_by=None):
     tags = ["pollard-weights", "pollard"]
     for ln in lanes:
         tags += LANE_TAGS.get(ln, [ln])
@@ -191,8 +220,12 @@ def frontmatter(base_model, lic, lanes, model_type):
     for t in tags:
         if t not in seen:
             seen.add(t); uniq.append(t)
-    lines = ["---", f"license: {lic}", f"base_model: {base_model}", "base_model_relation: quantized",
-             "quantized_by: PollardWeights", "pipeline_tag: text-generation", "language:", "- en", "tags:"]
+    lines = ["---", f"license: {lic}", f"base_model: {base_model}", "base_model_relation: quantized"]
+    # Better to say nothing than to credit the wrong account: an unattributed card is incomplete,
+    # a misattributed one is false.
+    if quantized_by:
+        lines.append(f"quantized_by: {quantized_by}")
+    lines += ["pipeline_tag: text-generation", "language:", "- en", "tags:"]
     lines += [f"- {t}" for t in uniq]
     lines.append("---")
     return "\n".join(lines)
@@ -204,6 +237,9 @@ def main():
     ap.add_argument("--model", required=True, help="base model id or dir (title/frontmatter/config)")
     ap.add_argument("--builds-from", help="workspace manifest key for builds (default: --model)")
     ap.add_argument("--base-model", help="base_model for the frontmatter (default: --model)")
+    ap.add_argument("--quantized-by", dest="quantized_by",
+                    help="HF account to credit (default: the owner of --repo/--upload, else your "
+                         "Hugging Face login)")
     ap.add_argument("--title", help="card title (default: basename of base model)")
     ap.add_argument("--params", help="param count, e.g. 2.5B (else estimated from config)")
     ap.add_argument("--license", dest="license_", help="license (else read off the base model's card)")
@@ -249,7 +285,10 @@ def main():
     builds = load_builds(a.builds_from or a.model, a.lane)
     lanes = sorted({b.get("lane") for b in builds if b.get("lane")}) or (["gguf"])
     name = a.title or os.path.basename(str(base_model).rstrip("/"))
-    repo = a.repo or f"PollardWeights/{name}-Pollard"
+    account = publishing_account(a.quantized_by, a.repo, a.upload)
+    # A placeholder reads as "fill this in"; a real-but-wrong repo id reads as an instruction, and
+    # sends people to download someone else's weights.
+    repo = a.repo or f"{account or PLACEHOLDER_OWNER}/{name}-Pollard"
     results = {}
     if a.results and os.path.exists(a.results):
         results = json.load(open(a.results))
@@ -288,7 +327,7 @@ def main():
     lane_word = {"gguf": "", "mlx": " for Apple Silicon", "gptq": " for vLLM/SGLang",
                  "mx": " for Blackwell/vLLM", "exl3": " for exllamav3"}.get(primary, "")
     # ---- frontmatter + hero
-    out = [frontmatter(base_model, lic, lanes, mtype), "", f"# {name} — Pollard", ""]
+    out = [frontmatter(base_model, lic, lanes, mtype, account), "", f"# {name} — Pollard", ""]
     if f16_gb and small_gb:
         out += [f"> ### Pollard shrank this model{lane_word}: **{f16_gb:.2f} GB (f16) → {small_gb:.2f} GB** — "
                 f"**{pct:.0f}% smaller, {x:.1f}× down**.",

--- a/tools/pollard_reclaim.py
+++ b/tools/pollard_reclaim.py
@@ -154,8 +154,9 @@ def main():
                     help="workspace to read manifests from (default $POLLARD_HOME)")
     ap.add_argument("--scan", action="append", default=[],
                     help="extra directory to scan for model files no manifest claims (repeatable)")
-    ap.add_argument("--owner", default="PollardWeights",
-                    help="HF account the builds were published under")
+    ap.add_argument("--owner", default=None,
+                    help="HF account the builds were published under (default: your Hugging Face "
+                         "login)")
     ap.add_argument("--repo", action="append", default=[],
                     help="also check against these repo ids (repeatable). Needed when a build was "
                          "published under a name the manifest key does not imply.")
@@ -174,9 +175,18 @@ def main():
     ap.add_argument("--json", action="store_true", help="machine-readable output")
     a = ap.parse_args()
 
+    # Defaulting this to PollardWeights meant anyone else running reclaim checked their local builds
+    # against OUR repos, so nothing ever matched and nothing was ever reclaimed. Their own account is
+    # the only sensible default; deletion is gated on a positive match, so an unknown owner simply
+    # finds nothing rather than removing anything.
+    from pollard_card import publishing_account
+    owner = a.owner or publishing_account()
+    if not owner:
+        sys.exit("no HF account known: pass --owner, or log in with `hf auth login`.")
+
     cands, seen, repos = [], set(), set(a.repo)
     for _, man in iter_manifests(a.home):
-        guesses = repo_guesses(man.get("model") or "", a.owner)
+        guesses = repo_guesses(man.get("model") or "", owner)
         repos.update(guesses)
         for b in man.get("builds", []):
             p = b.get("path")


### PR DESCRIPTION
Three commits, most significant first:

commit	fix
8d5f362	attribution follows the publisher, not PollardWeights
3f8ce6e	no double period on a calibration note that ends in one
aad20ed	number agreement when one rung needs ik_llama
The attribution one is the substantive change. publishing_account() resolves --quantized-by → owner of --repo/--upload → local HF login; if none answers it omits quantized_by rather than guessing, and falls back to a visible YOUR_HF_ACCOUNT placeholder for the repo id. pollard-reclaim had the identical bug — anyone else's reclaim was silently checking their local builds against your repos and matching nothing.