### PR TITLE
pollard-flybrain: accept lists, not just numpy arrays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,8 @@ pollard-envmatch = "pollard_envmatch:main"
 
 [tool.setuptools]
 package-dir = { "" = "tools" }
-py-modules = ["pollard_auto", "pollard_calc", "pollard_fit", "pollard_run", "pollard_fit_dit", "pollard_experts", "pollard_sensitivity", "pollard_smooth", "pollard_rotate", "pollard_precondition", "pollard_eval", "pollard_health", "pollard_pack", "pollard_prune", "pollard_bench", "pollard_export", "pollard_gptq", "pollard_automap", "pollard_abliterate", "pollard_probe", "pollard_probes", "pollard_scorecard", "pollard_kl", "pollard_lowbit", "pollard_verify", "pollard_doctor", "pollard_hf_smooth", "pollard_mx", "pollard_mlx", "pollard_exl3", "pollard_calib", "pollard_palette", "pollard_ls", "pollard_workspace",
+py-modules = ["pollard_auto", "pollard_calc", "pollard_fit", "pollard_run", "pollard_fit_dit",
+    "pollard_flybrain", "pollard_experts", "pollard_sensitivity", "pollard_smooth", "pollard_rotate", "pollard_precondition", "pollard_eval", "pollard_health", "pollard_pack", "pollard_prune", "pollard_bench", "pollard_export", "pollard_gptq", "pollard_automap", "pollard_abliterate", "pollard_probe", "pollard_probes", "pollard_scorecard", "pollard_kl", "pollard_lowbit", "pollard_verify", "pollard_doctor", "pollard_hf_smooth", "pollard_mx", "pollard_mlx", "pollard_exl3", "pollard_calib", "pollard_palette", "pollard_ls", "pollard_workspace",
     "pollard_serve_eval", "pollard_card", "pollard_onboard", "pollard_envmatch", "imatrix_fix_gate", "exl3_fix_mtp_ehproj",
     "pollard_archfp", "pollard_errtype", "pollard_errsrc", "pollard_recard",
     "pollard_ggufcompat", "pollard_reclaim", "pollard_exl3_band", "pollard_refcheck",

--- a/tools/pollard_flybrain.py
+++ b/tools/pollard_flybrain.py
@@ -42,9 +42,13 @@ class FlyBrain:
         self.meta = blob["meta"]
         self.device = device
         d = torch.device(device)
+        # Accept lists, numpy arrays or tensors. `sign` is per-neuron and has to be gathered onto
+        # the presynaptic side, which is numpy-style fancy indexing -- it raises on a plain list, and
+        # a checkpoint written from lists is a perfectly reasonable thing for someone to hand us.
         self.src = torch.as_tensor(blob["src"], dtype=torch.long, device=d)
         self.dst = torch.as_tensor(blob["dst"], dtype=torch.long, device=d)
-        self.sgn = torch.as_tensor(blob["sign"][blob["src"]], dtype=torch.float32, device=d)
+        sign = torch.as_tensor(blob["sign"], dtype=torch.float32, device=d)
+        self.sgn = sign[self.src]
         self.w = blob["w"].to(d).float()
         self.tau = torch.sigmoid(blob["tau"].to(d).float())
         self.write = blob["write"].to(d).float()


### PR DESCRIPTION
FlyBrain gathered the per-neuron signs onto the presynaptic side with `blob["sign"][blob["src"]]` -- numpy-style fancy indexing. Real checkpoints carry numpy arrays so it worked in practice, but a checkpoint written from plain lists raised `list indices must be integers or slices, not list` in the constructor, before anything else could run.

Converting to a tensor first and indexing there accepts lists, numpy arrays and tensors alike.

Caught by the box, where torch is installed and the test actually executes. The Mac skips that test for want of torch, which is why the suite read 37/37 there and 36/37 on the box for the same commit.