### PR TITLE
pollard-flybrain: say what to install instead of dumping a traceback

### DIFF
--- a/tools/pollard_flybrain.py
+++ b/tools/pollard_flybrain.py
@@ -28,8 +28,15 @@ import math
 import os
 from typing import Optional
 
-import torch
-import torch.nn as nn
+try:
+    import torch
+    import torch.nn as nn
+except ImportError as _e:      # the connectome lane is an optional extra, not a core dependency
+    raise SystemExit(
+        "pollard-flybrain needs PyTorch, which Pollard does not install by default.\n"
+        "  pip install 'pollard-weights[flybrain]'      (torch, transformers, pandas, scipy)\n"
+        f"({_e})"
+    ) from None
 
 __all__ = ["FlyBrain"]
 _STATE_MAGIC = b"FLYS"


### PR DESCRIPTION
torch is deliberately not a core Pollard dependency -- the connectome lane sits behind the [flybrain] extra so nobody's install grows by a couple of gigabytes for a feature they are not using. But a plain `pip install pollard-weights` registers the command, and running it raised a bare ModuleNotFoundError from an import at the top of the file.

Now it names the extra:

    pollard-flybrain needs PyTorch, which Pollard does not install by default.
      pip install 'pollard-weights[flybrain]'      (torch, transformers, pandas, scipy)

Found on the Mac, which has no torch. The box has it, so the command worked there and the gap was invisible from that side.